### PR TITLE
Run build script before packing the npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rabbitmq-stream-js-client",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Rabbit stream client for JS/TS application",
   "main": "dist/index.js",
   "scripts": {
@@ -10,7 +10,8 @@
     "check-ts": "tsc --noEmit && tsc --project test/tsconfig.json --noEmit",
     "check-lint": "tsc --noEmit && eslint 'src/**/*.ts' 'test/**/*.ts'",
     "check-format": "prettier -c 'src/**/*.ts' 'test/**/*.ts'",
-    "check-spell": "cspell 'src/**/*ts' 'test/**/*ts'"
+    "check-spell": "cspell 'src/**/*ts' 'test/**/*ts'",
+    "prepack": "npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This is a follow-up of #40 - what I assume happened is that before publishing version `0.0.4` to npm registry, `npm build` was not run so `0.0.4` actually does not contain declaration files.

This ensures it's always run before the package is created (using `npm pack`).