### PR TITLE
fix username duplicity

### DIFF
--- a/src/requests/sasl_authenticate_request.ts
+++ b/src/requests/sasl_authenticate_request.ts
@@ -16,6 +16,6 @@ export class SaslAuthenticateRequest extends AbstractRequest {
     writer.writeUInt8(0)
     writer.writeData(this.params.username)
     writer.writeUInt8(0)
-    writer.writeData(this.params.username)
+    writer.writeData(this.params.password)
   }
 }


### PR DESCRIPTION
there is obviously a bug causing inability to connect to rabbitmq instances where the username password is not the same