### PR TITLE
DeletePublisher Command

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -54,7 +54,6 @@ export class Connection {
   private heartbeat: Heartbeat
   private consumerId = 0
   private consumers = new Map<number, Consumer>()
-  private publishers = new Map<number, Producer>()
 
   constructor() {
     this.heartbeat = new Heartbeat(this, this.logger)
@@ -150,22 +149,15 @@ export class Connection {
     this.logger.info(
       `New producer created with stream name ${params.stream}, publisher id ${publisherId} and publisher reference ${params.publisherRef}`
     )
-    this.publishers.set(publisherId, producer)
 
     return producer
   }
 
   public async deletePublisher(publisherId: number) {
-    const publisher = this.publishers.get(publisherId)
-    if (!publisher) {
-      this.logger.error("Publisher does not exist")
-      throw new Error(`Publisher with id: ${publisherId} does not exist`)
-    }
     const res = await this.sendAndWait<DeletePublisherResponse>(new DeletePublisherRequest(publisherId))
     if (!res.ok) {
       throw new Error(`Delete Publisher command returned error with code ${res.code} - ${errorMessageOf(res.code)}`)
     }
-    this.publishers.delete(publisherId)
     this.logger.info(`deleted producer with publishing id ${publisherId}`)
     return res.ok
   }
@@ -460,6 +452,8 @@ function errorMessageOf(code: number): string {
   switch (code) {
     case 0x02:
       return "Stream does not exist"
+    case 0x12:
+      return "Publisher does not exist"
 
     default:
       return "Unknown error"

--- a/src/producer.ts
+++ b/src/producer.ts
@@ -101,7 +101,17 @@ export class Producer {
     )
   }
 
+<<<<<<< HEAD
   getLastPublishingId(): Promise<bigint> {
+||||||| parent of dc0ccf1 (DeletePublisher Command)
+  getLastPublishingId() {
+=======
+  getPublisherId() {
+    return this.publisherId
+  }
+
+  getLastPublishingId() {
+>>>>>>> dc0ccf1 (DeletePublisher Command)
     return this.connection.queryPublisherSequence({ stream: this.stream, publisherRef: this.publisherRef })
   }
 

--- a/src/producer.ts
+++ b/src/producer.ts
@@ -34,7 +34,7 @@ type PublishConfirmCallback = (err: number | null, publishingIds: bigint[]) => v
 export class Producer {
   private connection: Connection
   private stream: string
-  private publisherId: number
+  readonly publisherId: number
   private publisherRef: string
   private boot: boolean
   private publishingId: bigint
@@ -101,17 +101,7 @@ export class Producer {
     )
   }
 
-<<<<<<< HEAD
   getLastPublishingId(): Promise<bigint> {
-||||||| parent of dc0ccf1 (DeletePublisher Command)
-  getLastPublishingId() {
-=======
-  getPublisherId() {
-    return this.publisherId
-  }
-
-  getLastPublishingId() {
->>>>>>> dc0ccf1 (DeletePublisher Command)
     return this.connection.queryPublisherSequence({ stream: this.stream, publisherRef: this.publisherRef })
   }
 

--- a/src/requests/delete_publisher_request.ts
+++ b/src/requests/delete_publisher_request.ts
@@ -1,0 +1,16 @@
+import { DeletePublisherResponse } from "../responses/delete_publisher_response"
+import { AbstractRequest } from "./abstract_request"
+import { DataWriter } from "./data_writer"
+
+export class DeletePublisherRequest extends AbstractRequest {
+  readonly responseKey = DeletePublisherResponse.key
+  readonly key = 0x0006
+
+  constructor(private publisherId: number) {
+    super()
+  }
+
+  writeContent(writer: DataWriter) {
+    writer.writeUInt8(this.publisherId)
+  }
+}

--- a/src/response_decoder.ts
+++ b/src/response_decoder.ts
@@ -4,8 +4,9 @@ import { Logger } from "winston"
 import { DecoderListenerFunc } from "./decoder_listener"
 import { AbstractTypeClass } from "./responses/abstract_response"
 import { CloseResponse } from "./responses/close_response"
-import { CreateStreamResponse } from "./responses/create_stream_response"
 import { DeclarePublisherResponse } from "./responses/declare_publisher_response"
+import { DeletePublisherResponse } from "./responses/delete_publisher_response"
+import { CreateStreamResponse } from "./responses/create_stream_response"
 import { DeleteStreamResponse } from "./responses/delete_stream_response"
 import { HeartbeatResponse } from "./responses/heartbeat_response"
 import { MetadataUpdateResponse } from "./responses/metadata_update_response"
@@ -464,6 +465,7 @@ export class ResponseDecoder {
     this.addFactoryFor(OpenResponse)
     this.addFactoryFor(CloseResponse)
     this.addFactoryFor(DeclarePublisherResponse)
+    this.addFactoryFor(DeletePublisherResponse)
     this.addFactoryFor(CreateStreamResponse)
     this.addFactoryFor(DeleteStreamResponse)
     this.addFactoryFor(QueryPublisherResponse)

--- a/src/responses/delete_publisher_response.ts
+++ b/src/responses/delete_publisher_response.ts
@@ -1,0 +1,12 @@
+import { AbstractResponse } from "./abstract_response"
+import { RawResponse } from "./raw_response"
+
+export class DeletePublisherResponse extends AbstractResponse {
+  static key = 0x8006
+  readonly properties: Record<string, string> = {}
+
+  constructor(response: RawResponse) {
+    super(response)
+    this.verifyKey(DeletePublisherResponse)
+  }
+}

--- a/test/unit/delete_publisher.test.ts
+++ b/test/unit/delete_publisher.test.ts
@@ -1,0 +1,60 @@
+import { connect } from "../../src"
+import { expect } from "chai"
+import { Rabbit } from "../support/rabbit"
+import { randomUUID } from "crypto"
+import { expectToThrowAsync, username, password } from "../support/util"
+
+describe("DeletePublisher command", () => {
+  const rabbit = new Rabbit(username, password)
+  const testStreamName = "test-stream"
+  let publisherRef: string
+
+  beforeEach(async () => {
+    publisherRef = randomUUID()
+    await rabbit.createStream(testStreamName)
+  })
+
+  afterEach(() => rabbit.deleteStream(testStreamName))
+
+  it("can delete a publisher", async () => {
+    const connection = await connect({
+      hostname: "localhost",
+      port: 5552,
+      username,
+      password,
+      vhost: "/",
+      frameMax: 0,
+      heartbeat: 0,
+    })
+    const publisher = await connection.declarePublisher({ stream: testStreamName, publisherRef })
+    await publisher.send(Buffer.from(`test${randomUUID()}`))
+
+    const publisherId = publisher.getPublisherId()
+
+    const deletePublisher = await connection.deletePublisher(Number(publisherId))
+    expect(deletePublisher).eql(true)
+
+    await connection.close()
+  }).timeout(10000)
+
+  it("errors when deleting a publisher that does not exist", async () => {
+    const connection = await connect({
+      hostname: "localhost",
+      port: 5552,
+      username,
+      password,
+      vhost: "/",
+      frameMax: 0,
+      heartbeat: 0,
+    })
+    const nonExistentPublisherId = 42
+
+    await expectToThrowAsync(
+      () => connection.deletePublisher(Number(nonExistentPublisherId)),
+      Error,
+      "Publisher with id: 42 does not exist"
+    )
+
+    await connection.close()
+  }).timeout(10000)
+})

--- a/test/unit/delete_publisher.test.ts
+++ b/test/unit/delete_publisher.test.ts
@@ -1,60 +1,44 @@
-import { connect } from "../../src"
+import { Connection } from "../../src"
 import { expect } from "chai"
 import { Rabbit } from "../support/rabbit"
 import { randomUUID } from "crypto"
 import { expectToThrowAsync, username, password } from "../support/util"
+import { createConnection } from "../support/fake_data"
 
 describe("DeletePublisher command", () => {
   const rabbit = new Rabbit(username, password)
   const testStreamName = "test-stream"
+  let connection: Connection
   let publisherRef: string
 
   beforeEach(async () => {
     publisherRef = randomUUID()
     await rabbit.createStream(testStreamName)
+    connection = await createConnection(username, password)
   })
 
-  afterEach(() => rabbit.deleteStream(testStreamName))
+  afterEach(async () => {
+    await connection.close()
+    await rabbit.deleteStream(testStreamName)
+  })
 
   it("can delete a publisher", async () => {
-    const connection = await connect({
-      hostname: "localhost",
-      port: 5552,
-      username,
-      password,
-      vhost: "/",
-      frameMax: 0,
-      heartbeat: 0,
-    })
     const publisher = await connection.declarePublisher({ stream: testStreamName, publisherRef })
     await publisher.send(Buffer.from(`test${randomUUID()}`))
 
-    const publisherId = publisher.getPublisherId()
+    const publisherId = publisher.publisherId
 
     const deletePublisher = await connection.deletePublisher(Number(publisherId))
     expect(deletePublisher).eql(true)
-
-    await connection.close()
   }).timeout(10000)
 
   it("errors when deleting a publisher that does not exist", async () => {
-    const connection = await connect({
-      hostname: "localhost",
-      port: 5552,
-      username,
-      password,
-      vhost: "/",
-      frameMax: 0,
-      heartbeat: 0,
-    })
     const nonExistentPublisherId = 42
 
     await expectToThrowAsync(
       () => connection.deletePublisher(Number(nonExistentPublisherId)),
       Error,
-      "Publisher with id: 42 does not exist"
+      "Delete Publisher command returned error with code 18 - Publisher does not exist"
     )
-
-    await connection.close()
   }).timeout(10000)
 })


### PR DESCRIPTION
Hello! This PR adds the DeletePublisher Command

https://github.com/rabbitmq/rabbitmq-server/blob/1ee8454129b7769fda6dfc1a528e886b290aa258/deps/rabbitmq_stream/docs/PROTOCOL.adoc#deletepublisher

connection.ts can handle sending DeletePublisher requests, and parsing DeletePublisherResponse.

I also exposed the publishingId on the producer class, since publishingId is required in DeletePublisherRequest. 

Tests passing with `npm run test`
