### PR TITLE
Specify disconnect hook

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,8 +21,9 @@ jobs:
     services:
       rabbitmq:
         image: rabbitmq:3-management
+        options: --hostname test-node
         env:
-          RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS: -rabbitmq_stream advertised_host localhost
+          # RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS: -rabbitmq_stream advertised_host localhost
           RABBITMQ_DEFAULT_USER: "test-user"
           RABBITMQ_DEFAULT_PASS: "test-password"
         ports:
@@ -50,6 +51,7 @@ jobs:
         env:
           RABBITMQ_USER: "test-user"
           RABBITMQ_PASSWORD: "test-password"
+          RABBIT_MQ_TEST_NODES: "test-node:5552"
       - run: cd example && npm install && npm start
         env:
           RABBITMQ_USER: "test-user"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,6 @@ jobs:
         image: rabbitmq:3-management
         options: --hostname test-node
         env:
-          # RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS: -rabbitmq_stream advertised_host localhost
           RABBITMQ_DEFAULT_USER: "test-user"
           RABBITMQ_DEFAULT_PASS: "test-password"
         ports:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,6 +34,8 @@ jobs:
           - 61613:61613
 
     steps:
+      - name: Add the rabbitmq service to /etc/hosts
+        run: sudo echo "127.0.0.1 test-node" | sudo tee -a /etc/hosts
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist/
 node_modules/
 performance_test/node_modules
+.envrc

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,2 @@
 nodejs 16.15.1
+python 3.8.12

--- a/Makefile
+++ b/Makefile
@@ -4,5 +4,6 @@ rabbitmq-cluster:
 	mv cluster/tls-gen/basic/result/server_*_certificate.pem cluster/tls-gen/basic/result/server_certificate.pem
 	mv cluster/tls-gen/basic/result/server_*key.pem cluster/tls-gen/basic/result/server_key.pem
 	cd cluster; docker build -t haproxy-rabbitmq-cluster  .
+	cd cluster; chmod 755 -R tls-gen 
 	cd cluster; docker compose down
 	cd cluster; docker compose up -d

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+rabbitmq-cluster:
+	cd cluster; rm -rf tls-gen;
+	cd cluster; git clone https://github.com/michaelklishin/tls-gen tls-gen; cd tls-gen/basic; make
+	mv cluster/tls-gen/basic/result/server_*_certificate.pem cluster/tls-gen/basic/result/server_certificate.pem
+	mv cluster/tls-gen/basic/result/server_*key.pem cluster/tls-gen/basic/result/server_key.pem
+	cd cluster; docker build -t haproxy-rabbitmq-cluster  .
+	cd cluster; docker compose down
+	cd cluster; docker compose up -d

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A rapid getting started
 const rabbit = require("rabbitmq-stream-js-client")
 
 async function main() {
-  const connection = await rabbit.connect({
+  const client = await rabbit.connect({
     hostname: "localhost",
     port: 5552,
     username: "rabbit",
@@ -31,7 +31,7 @@ async function main() {
     vhost: "/",
   })
 
-  await connection.close()
+  await client.close()
 }
 
 main()
@@ -46,7 +46,7 @@ main()
 ### Connect
 
 ```typescript
-const connection = await connect({
+const client = await connect({
   hostname: "localhost",
   port: 5552,
   username: "rabbit",
@@ -56,7 +56,7 @@ const connection = await connect({
 
 // ...
 
-await connection.close()
+await client.close()
 ```
 
 ## Build from source

--- a/cluster/.gitignore
+++ b/cluster/.gitignore
@@ -1,0 +1,2 @@
+tls-gen/
+.DS_Store

--- a/cluster/Dockerfile
+++ b/cluster/Dockerfile
@@ -1,0 +1,3 @@
+FROM haproxy:2.2.22
+
+COPY haproxy.cfg /usr/local/etc/haproxy/haproxy.cfg

--- a/cluster/README.md
+++ b/cluster/README.md
@@ -10,6 +10,15 @@ add the following to your `/etc/hosts`
 127.0.0.1       node2
 ```
 
+set the following values in your environment if you want to run the tests
+```
+RABBITMQ_USER="rabbit"
+RABBITMQ_PASSWORD="rabbit"
+RABBIT_MQ_MANAGEMENT_PORT=15673
+RABBIT_MQ_AMQP_PORT=5555
+RABBIT_MQ_TEST_NODES="node0:5562;node1:5572;node2:5582"
+```
+
 then run the following
 
 ```bash

--- a/cluster/README.md
+++ b/cluster/README.md
@@ -1,0 +1,25 @@
+RabbitMQ cluster with HA proxy 
+===
+
+how to run:
+
+add the following to your `/etc/hosts`
+```
+127.0.0.1       node0
+127.0.0.1       node1
+127.0.0.1       node2
+```
+
+then run the following
+
+```bash
+git clone git@github.com:rabbitmq/rabbitmq-stream-js-client.git .
+make rabbitmq-cluster
+```
+
+ports:
+```
+ - localhost:5553 #standard stream port
+ - localhost:5554 #TLS stream port
+ - http://localhost:15673 #management port
+```

--- a/cluster/conf/enabled_plugins
+++ b/cluster/conf/enabled_plugins
@@ -1,0 +1,1 @@
+[rabbitmq_management, rabbitmq_stream, rabbitmq_stream_management].

--- a/cluster/conf/rabbitmq.conf
+++ b/cluster/conf/rabbitmq.conf
@@ -1,0 +1,17 @@
+cluster_formation.peer_discovery_backend  = rabbit_peer_discovery_classic_config
+
+cluster_formation.classic_config.nodes.1 = rabbit@node0
+cluster_formation.classic_config.nodes.2 = rabbit@node1
+cluster_formation.classic_config.nodes.3 = rabbit@node2
+loopback_users.guest = false
+
+ssl_options.cacertfile = /certs/ca_certificate.pem
+ssl_options.certfile = /certs/server_certificate.pem
+ssl_options.keyfile = /certs/server_key.pem
+listeners.ssl.default = 5671
+listeners.tcp.default = 5550
+stream.listeners.tcp.default = 5552
+stream.listeners.ssl.default = 5551
+ssl_options.verify               = verify_peer
+ssl_options.fail_if_no_peer_cert = false
+log.file.level = debug

--- a/cluster/docker-compose.yml
+++ b/cluster/docker-compose.yml
@@ -1,0 +1,68 @@
+version: "1"
+services:
+  rabbit_node0:
+    environment:
+      - RABBITMQ_ERLANG_COOKIE='secret_cookie'
+      - RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS=-rabbitmq_stream advertised_host node0 advertised_port 5562
+      - RABBITMQ_DEFAULT_USER=rabbit
+      - RABBITMQ_DEFAULT_PASS=rabbit
+    networks:
+      - back
+    hostname: node0
+    image: docker.io/rabbitmq:3-management
+    ports:
+      - "5560:5550"
+      - "5561:5551"
+      - "5562:5552"
+    tty: true
+    volumes:
+     - ./conf/:/etc/rabbitmq/
+     - "./tls-gen/basic/result/:/certs"
+  rabbit_node1:
+    environment:
+      - RABBITMQ_ERLANG_COOKIE='secret_cookie'
+      - RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS=-rabbitmq_stream advertised_host node1 advertised_port 5572
+      - RABBITMQ_DEFAULT_USER=rabbit
+      - RABBITMQ_DEFAULT_PASS=rabbit
+    networks:
+      - back
+    hostname: node1
+    image: docker.io/rabbitmq:3-management
+    ports:
+      - "5570:5550"
+      - "5571:5551"
+      - "5572:5552"
+    tty: true
+    volumes:
+      - ./conf/:/etc/rabbitmq/
+      - "./tls-gen/basic/result/:/certs"
+  rabbit_node2:
+    environment:
+      - RABBITMQ_ERLANG_COOKIE='secret_cookie'
+      - RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS=-rabbitmq_stream advertised_host node2 advertised_port 5582
+      - RABBITMQ_DEFAULT_USER=rabbit
+      - RABBITMQ_DEFAULT_PASS=rabbit
+    networks:
+      - back
+    hostname: node2
+    image: docker.io/rabbitmq:3-management
+    ports:
+      - "5580:5550"
+      - "5581:5551"
+      - "5582:5552"
+    tty: true
+    volumes:
+      - ./conf/:/etc/rabbitmq/
+      - "./tls-gen/basic/result/:/certs"
+  haproxy:
+    image: haproxy-rabbitmq-cluster
+    hostname: haproxy
+    ports:
+      - "5553:5552"
+      - "5554:5551"
+      - "5555:5550"
+      - "15673:15672"
+    networks:
+      - back
+networks:
+  back:

--- a/cluster/haproxy.cfg
+++ b/cluster/haproxy.cfg
@@ -1,0 +1,43 @@
+global
+    maxconn 4096
+    log stdout format raw local0 debug
+
+defaults
+    timeout connect 60s
+    timeout client 60s
+    timeout server 60s
+    log global
+
+frontend tcp-0_0_0_0-443
+    bind *:5551
+    mode tcp
+    use_backend rabbitmq-stream-tls
+    tcp-request inspect-delay 5s
+    tcp-request content accept if { req_ssl_hello_type 1 }
+
+backend rabbitmq-stream-tls
+    mode tcp
+    server rabbit_node0 rabbit_node0:5551 check inter 5000 fall 3
+    server rabbit_node1 rabbit_node1:5551 check inter 5000 fall 3
+    server rabbit_node2 rabbit_node2:5551 check inter 5000 fall 3
+
+listen rabbitmq-stream
+    bind 0.0.0.0:5552
+    balance roundrobin
+    server rabbit_node0 rabbit_node0:5552 check inter 5000 fall 3
+    server rabbit_node1 rabbit_node1:5552 check inter 5000 fall 3
+    server rabbit_node2 rabbit_node2:5552 check inter 5000 fall 3
+
+listen rabbitmq-classic
+    bind 0.0.0.0:5550
+    balance roundrobin
+    server rabbit_node0 rabbit_node0:5550 check inter 5000 fall 3
+    server rabbit_node1 rabbit_node1:5550 check inter 5000 fall 3
+    server rabbit_node2 rabbit_node2:5550 check inter 5000 fall 3
+
+listen rabbitmq-ui
+    bind 0.0.0.0:15672
+    balance roundrobin
+    server rabbit_node0 rabbit_node0:15672 check inter 5000 fall 3
+    server rabbit_node1 rabbit_node1:15672 check inter 5000 fall 3
+    server rabbit_node2 rabbit_node2:15672 check inter 5000 fall 3

--- a/cspell.json
+++ b/cspell.json
@@ -1,4 +1,4 @@
 {
   "language": "en",
-  "words": ["ackmode", "ampq", "prefetch", "amqpvalue", "RABBITMQ", "Sasl", "Vbin", "akey"]
+  "words": ["ackmode", "ampq", "prefetch", "amqpvalue", "RABBITMQ", "Sasl", "Vbin", "akey", "tarza"]
 }

--- a/cspell.json
+++ b/cspell.json
@@ -1,4 +1,4 @@
 {
   "language": "en",
-  "words": ["ackmode", "ampq", "prefetch", "amqpvalue", "RABBITMQ", "Sasl", "Vbin", "akey", "tarza"]
+  "words": ["ackmode", "ampq", "prefetch", "amqpvalue", "RABBITMQ", "Sasl", "Vbin", "akey"]
 }

--- a/example/index.js
+++ b/example/index.js
@@ -9,7 +9,7 @@ async function main() {
   const streamName = `example-${randomUUID()}`
   console.log(`Create stream ${streamName}`)
 
-  const connection = await rabbit.connect({
+  const client = await rabbit.connect({
     hostname: "localhost",
     port: 5552,
     username: rabbitUser,
@@ -17,16 +17,16 @@ async function main() {
     vhost: "/",
     heartbeat: 0,
   })
-  await connection.createStream({ stream: streamName, arguments: {} })
-  const producer = await connection.declarePublisher({ stream: streamName })
+  await client.createStream({ stream: streamName, arguments: {} })
+  const producer = await client.declarePublisher({ stream: streamName })
 
   await producer.send(Buffer.from("ciao"))
 
   await createClassicConsumer(streamName)
 
-  await connection.deleteStream({ stream: streamName })
+  await client.deleteStream({ stream: streamName })
 
-  await connection.close()
+  await client.close()
 }
 
 /**

--- a/performance_test/index.ts
+++ b/performance_test/index.ts
@@ -42,7 +42,7 @@ async function main() {
   const bufferSizeSettings: BufferSizeSettings = { initialSize: 16384 }
   const frameMax = 65536
 
-  const connection = await connect(
+  const client = await connect(
     {
       hostname: "localhost",
       port: 5552,
@@ -56,7 +56,7 @@ async function main() {
   )
 
   const streamName = `my-stream-${randomUUID()}`
-  await connection.createStream({ stream: streamName, arguments: {} })
+  await client.createStream({ stream: streamName, arguments: {} })
   const publisherRef = `my-publisher-${randomUUID()}`
   const passedArgs = parseArgs(argv.slice(2))
   logger.info(
@@ -66,7 +66,7 @@ async function main() {
   )
 
   const perfTestProducer = new PerfTestProducer(
-    connection,
+    client,
     logger,
     passedArgs.maxMessages,
     { stream: streamName, publisherRef: publisherRef },

--- a/performance_test/perf_test_producer.ts
+++ b/performance_test/perf_test_producer.ts
@@ -1,6 +1,6 @@
 import { inspect } from "util"
 import { Metrics } from "./metrics"
-import { Connection, DeclarePublisherParams, Producer } from "rabbitmq-stream-js-client"
+import { Client, DeclarePublisherParams, Producer } from "rabbitmq-stream-js-client"
 import { Logger } from "winston"
 
 export class PerfTestProducer {
@@ -11,7 +11,7 @@ export class PerfTestProducer {
   private displayTimer: NodeJS.Timeout | null
 
   constructor(
-    private readonly connection: Connection,
+    private readonly client: Client,
     private readonly logger: Logger,
     private readonly maxMessages: number,
     private readonly publisherParams: DeclarePublisherParams,
@@ -24,7 +24,7 @@ export class PerfTestProducer {
   }
 
   public async cycle() {
-    const publisher = await this.connection.declarePublisher(this.publisherParams)
+    const publisher = await this.client.declarePublisher(this.publisherParams)
     publisher.on("publish_confirm", (err, confirmedIds) => {
       if (err) {
         this.logger.error(err)

--- a/src/client.ts
+++ b/src/client.ts
@@ -200,7 +200,7 @@ export class Client {
     const { stream, publisherRef } = params
     const publisherId = this.incPublisherId()
 
-    const client = await this.initNewClient(params.stream, false)
+    const client = await this.initNewClient(params.stream, true)
     const res = await client.sendAndWait<DeclarePublisherResponse>(
       new DeclarePublisherRequest({ stream, publisherRef, publisherId })
     )
@@ -633,9 +633,10 @@ function errorMessageOf(code: number): string {
   switch (code) {
     case 0x02:
       return "Stream does not exist"
+    case 0x06:
+      return "Stream not available"
     case 0x12:
       return "Publisher does not exist"
-
     default:
       return "Unknown error"
   }

--- a/src/client.ts
+++ b/src/client.ts
@@ -557,7 +557,7 @@ export class Client {
     const [metadata] = await this.queryMetadata({ streams: [streamName] })
     const chosenNode = leader ? metadata.leader : sample([metadata.leader, ...(metadata.replicas ?? [])])
     if (!chosenNode) {
-      // need some help with this error message -- what might be better than this? --Luca (20/12/23)
+      // need some help with this error message -- what might be better than this? --tarza (20/12/23)
       throw new Error(`Stream was not found on any node`)
     }
     const newClient = await connect({ ...this.params, hostname: chosenNode.host, port: chosenNode.port }, this.logger)

--- a/src/client.ts
+++ b/src/client.ts
@@ -557,7 +557,6 @@ export class Client {
     const [metadata] = await this.queryMetadata({ streams: [streamName] })
     const chosenNode = leader ? metadata.leader : sample([metadata.leader, ...(metadata.replicas ?? [])])
     if (!chosenNode) {
-      // need some help with this error message -- what might be better than this? --tarza (20/12/23)
       throw new Error(`Stream was not found on any node`)
     }
     const newClient = await connect({ ...this.params, hostname: chosenNode.host, port: chosenNode.port }, this.logger)

--- a/src/client.ts
+++ b/src/client.ts
@@ -107,7 +107,7 @@ export class Client {
   }
 
   static async connect(params: ConnectionParams, logger?: Logger): Promise<Client> {
-    return new Client(logger ?? new NullLogger(), { ...params, hostname: params.hostname }).start()
+    return new Client(logger ?? new NullLogger(), params).start()
   }
 
   public start(): Promise<Client> {

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -7,6 +7,7 @@ export interface Consumer {
   close(): Promise<void>
   storeOffset(offsetValue: bigint): Promise<void>
   queryOffset(): Promise<bigint>
+  getConnectionInfo(): { host: string; port: number; id: string }
   consumerId: number
   consumerRef?: string
 }
@@ -33,7 +34,7 @@ export class StreamConsumer implements Consumer {
   }
 
   async close(): Promise<void> {
-    throw new Error("Method not implemented.")
+    await this.client.close()
   }
 
   public storeOffset(offsetValue: bigint): Promise<void> {
@@ -44,5 +45,9 @@ export class StreamConsumer implements Consumer {
   public queryOffset(): Promise<bigint> {
     if (!this.consumerRef) throw new Error("ConsumerReference must be defined in order to use this!")
     return this.client.queryOffset({ stream: this.stream, reference: this.consumerRef })
+  }
+
+  public getConnectionInfo(): { host: string; port: number; id: string } {
+    return this.client.getConnectionInfo()
   }
 }

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -1,4 +1,4 @@
-import { Connection } from "./connection"
+import { Client } from "./client"
 import { Message } from "./producer"
 
 export type ConsumerFunc = (message: Message) => void
@@ -12,7 +12,7 @@ export interface Consumer {
 }
 
 export class StreamConsumer implements Consumer {
-  private connection: Connection
+  private client: Client
   private stream: string
   public consumerId: number
   public consumerRef?: string
@@ -20,13 +20,13 @@ export class StreamConsumer implements Consumer {
   constructor(
     readonly handle: ConsumerFunc,
     params: {
-      connection: Connection
+      client: Client
       stream: string
       consumerId: number
       consumerRef?: string
     }
   ) {
-    this.connection = params.connection
+    this.client = params.client
     this.stream = params.stream
     this.consumerId = params.consumerId
     this.consumerRef = params.consumerRef
@@ -38,11 +38,11 @@ export class StreamConsumer implements Consumer {
 
   public storeOffset(offsetValue: bigint): Promise<void> {
     if (!this.consumerRef) throw new Error("ConsumerReference must be defined in order to use this!")
-    return this.connection.storeOffset({ stream: this.stream, reference: this.consumerRef, offsetValue })
+    return this.client.storeOffset({ stream: this.stream, reference: this.consumerRef, offsetValue })
   }
 
   public queryOffset(): Promise<bigint> {
     if (!this.consumerRef) throw new Error("ConsumerReference must be defined in order to use this!")
-    return this.connection.queryOffset({ stream: this.stream, reference: this.consumerRef })
+    return this.client.queryOffset({ stream: this.stream, reference: this.consumerRef })
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export * from "./connection"
+export * from "./client"
 export { Producer } from "./producer"
 export { Consumer } from "./consumer"

--- a/src/util.ts
+++ b/src/util.ts
@@ -15,3 +15,12 @@ export function range(count: number): number[] {
 
 export const DEFAULT_FRAME_MAX = 1048576
 export const DEFAULT_UNLIMITED_FRAME_MAX = 0
+
+export const getTestNodesFromEnv = (): { host: string; port: number }[] => {
+  const envValue = process.env.RABBIT_MQ_TEST_NODES ?? "localhost:5552"
+  const nodes = envValue.split(";")
+  return nodes.map((n) => {
+    const [host, port] = n.split(":")
+    return { host: host ?? "localhost", port: parseInt(port) ?? 5552 }
+  })
+}

--- a/test/e2e/basic_publish.test.ts
+++ b/test/e2e/basic_publish.test.ts
@@ -1,8 +1,8 @@
 import { expect } from "chai"
 import { randomUUID } from "crypto"
-import { Connection } from "../../src"
+import { Client } from "../../src"
 import { Producer } from "../../src/producer"
-import { createConnection, createProperties, createPublisher, createStreamName } from "../support/fake_data"
+import { createClient, createProperties, createPublisher, createStreamName } from "../support/fake_data"
 import { Rabbit } from "../support/rabbit"
 import { eventually, username, password, getMessageFrom } from "../support/util"
 import { BufferSizeSettings } from "../../src/requests/request"
@@ -10,22 +10,22 @@ import { FrameSizeException } from "../../src/requests/frame_size_exception"
 
 describe("publish a message", () => {
   const rabbit = new Rabbit(username, password)
-  let connection: Connection
+  let client: Client
   let streamName: string
   let publisher: Producer
   let bufferSizeSettings: BufferSizeSettings | undefined = undefined
   let maxFrameSize: number | undefined = undefined
 
   beforeEach(async () => {
-    connection = await createConnection(username, password, undefined, maxFrameSize, bufferSizeSettings)
+    client = await createClient(username, password, undefined, maxFrameSize, bufferSizeSettings)
     streamName = createStreamName()
     await rabbit.createStream(streamName)
-    publisher = await createPublisher(streamName, connection)
+    publisher = await createPublisher(streamName, client)
   })
 
   afterEach(async () => {
     try {
-      await connection.close()
+      await client.close()
       await rabbit.deleteStream(streamName)
       await rabbit.closeAllConnections()
       await rabbit.deleteAllQueues({ match: /my-stream-/ })
@@ -131,7 +131,7 @@ describe("publish a message", () => {
     }).timeout(30000)
 
     it("is not active if create a publisher with empty publisherRef", async () => {
-      const publisherEmptyRef = await connection.declarePublisher({ stream: streamName, publisherRef: "" })
+      const publisherEmptyRef = await client.declarePublisher({ stream: streamName, publisherRef: "" })
 
       const howMany = 100
       for (let index = 0; index < howMany; index++) {
@@ -145,7 +145,7 @@ describe("publish a message", () => {
     }).timeout(30000)
 
     it("is not active if create a publisher without publishRef", async () => {
-      const publisherNoRef = await connection.declarePublisher({ stream: streamName })
+      const publisherNoRef = await client.declarePublisher({ stream: streamName })
 
       const howMany = 100
       for (let index = 0; index < howMany; index++) {

--- a/test/e2e/close_consumer.test.ts
+++ b/test/e2e/close_consumer.test.ts
@@ -1,39 +1,39 @@
 import { expect } from "chai"
-import { Connection } from "../../src"
+import { Client } from "../../src"
 import { Offset } from "../../src/requests/subscribe_request"
 import { Rabbit } from "../support/rabbit"
 import { expectToThrowAsync, password, username } from "../support/util"
-import { createConnection } from "../support/fake_data"
+import { createClient } from "../support/fake_data"
 
 describe("close consumer", () => {
   const rabbit = new Rabbit(username, password)
   const testStreamName = "test-stream"
-  let connection: Connection
+  let client: Client
 
   beforeEach(async () => {
     await rabbit.createStream(testStreamName)
-    connection = await createConnection(username, password)
+    client = await createClient(username, password)
   })
 
   afterEach(async () => {
-    await connection.close()
+    await client.close()
     await rabbit.deleteStream(testStreamName)
   })
 
   it("closing a consumer in an existing stream", async () => {
-    await connection.declarePublisher({ stream: testStreamName })
-    const consumer = await connection.declareConsumer({ stream: testStreamName, offset: Offset.first() }, console.log)
+    await client.declarePublisher({ stream: testStreamName })
+    const consumer = await client.declareConsumer({ stream: testStreamName, offset: Offset.first() }, console.log)
 
-    const response = await connection.closeConsumer(consumer.consumerId)
+    const response = await client.closeConsumer(consumer.consumerId)
 
     expect(response).eql(true)
-    expect(connection.consumerCounts()).eql(0)
+    expect(client.consumerCounts()).eql(0)
   }).timeout(5000)
 
   it("closing a non-existing consumer should rise an error", async () => {
     const nonExistingConsumerId = 123456
-    await connection.declarePublisher({ stream: testStreamName })
+    await client.declarePublisher({ stream: testStreamName })
 
-    await expectToThrowAsync(() => connection.closeConsumer(nonExistingConsumerId), Error)
+    await expectToThrowAsync(() => client.closeConsumer(nonExistingConsumerId), Error)
   })
 })

--- a/test/e2e/cluster_connection_management.test.ts
+++ b/test/e2e/cluster_connection_management.test.ts
@@ -1,0 +1,66 @@
+import { expect } from "chai"
+import { Client } from "../../src"
+import { createClient, createConsumer, createPublisher, createStreamName } from "../support/fake_data"
+import { Rabbit } from "../support/rabbit"
+import { password, username } from "../support/util"
+
+describe("connection management for clusters (applicable even on a single node)", () => {
+  const rabbit = new Rabbit(username, password)
+  let client: Client
+  let streamName: string
+
+  beforeEach(async () => {
+    client = await createClient(username, password)
+    streamName = createStreamName()
+    await rabbit.createStream(streamName)
+  })
+
+  afterEach(async () => {
+    try {
+      await client.close()
+      await rabbit.deleteStream(streamName)
+      await rabbit.closeAllConnections()
+      await rabbit.deleteAllQueues({ match: /my-stream-/ })
+    } catch (e) {}
+  })
+
+  it("when we create a consumer, a new connection is opened", async () => {
+    const clientConnectionInfo = client.getConnectionInfo()
+
+    const consumer = await createConsumer(streamName, client)
+
+    const consumerConnectionInfo = consumer.getConnectionInfo()
+    expect(clientConnectionInfo.id).to.not.be.equal(consumerConnectionInfo.id)
+  }).timeout(10000)
+
+  it("when we create a producer, a new connection is opened", async () => {
+    const clientConnectionInfo = client.getConnectionInfo()
+
+    const publisher = await createPublisher(streamName, client)
+
+    const publisherConnectionInfo = publisher.getConnectionInfo()
+    expect(clientConnectionInfo.id).to.not.be.equal(publisherConnectionInfo.id)
+  }).timeout(10000)
+
+  it("when we create a producer, the connection should be done on the leader", async () => {
+    const streamInfo = await rabbit.getQueue("%2F", streamName)
+    const leader = streamInfo.node
+    const [leaderHostName] = leader.split("@").slice(-1)
+
+    const publisher = await createPublisher(streamName, client)
+
+    const connectionInfo = publisher.getConnectionInfo()
+    expect(connectionInfo.host).to.be.equal(leaderHostName)
+  }).timeout(10000)
+
+  it("closing the client closes all producers and consumers - no connection is left hanging", async () => {
+    await createConsumer(streamName, client)
+    await createConsumer(streamName, client)
+    await createPublisher(streamName, client)
+
+    await client.close()
+
+    expect(client.consumerCounts()).to.be.equal(0)
+    expect(client.producerCounts()).to.be.equal(0)
+  }).timeout(10000)
+})

--- a/test/e2e/connect.test.ts
+++ b/test/e2e/connect.test.ts
@@ -1,20 +1,20 @@
 import { expect } from "chai"
-import { Connection } from "../../src"
-import { createConnection } from "../support/fake_data"
+import { Client } from "../../src"
+import { createClient } from "../support/fake_data"
 import { Rabbit } from "../support/rabbit"
 import { eventually, username, password } from "../support/util"
 
 describe("connect", () => {
-  let connection: Connection
+  let client: Client
   const rabbit = new Rabbit(username, password)
 
   beforeEach(async () => {
-    connection = await createConnection(username, password)
+    client = await createClient(username, password)
   })
 
   afterEach(async () => {
     try {
-      await connection.close()
+      await client.close()
     } catch (e) {}
 
     try {

--- a/test/e2e/connect_frame_size_negotiation.test.ts
+++ b/test/e2e/connect_frame_size_negotiation.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai"
-import { createConnection } from "../support/fake_data"
+import { createClient } from "../support/fake_data"
 import { Rabbit } from "../support/rabbit"
 import { eventually, username, password } from "../support/util"
 
@@ -9,14 +9,14 @@ describe("connect frame size negotiation", () => {
   it("using 65536 as frameMax", async () => {
     const frameMax = 65536
 
-    const connection = await createConnection(username, password, undefined, frameMax)
+    const client = await createClient(username, password, undefined, frameMax)
 
     await eventually(async () => {
-      expect(connection.currentFrameMax).lte(frameMax)
+      expect(client.currentFrameMax).lte(frameMax)
       expect(await rabbit.getConnections()).lengthOf(1)
     }, 5000)
     try {
-      await connection.close()
+      await client.close()
       await rabbit.closeAllConnections()
     } catch (e) {}
   }).timeout(10000)
@@ -24,14 +24,14 @@ describe("connect frame size negotiation", () => {
   it("using 1024 as frameMax", async () => {
     const frameMax = 1024
 
-    const connection = await createConnection(username, password, undefined, frameMax)
+    const client = await createClient(username, password, undefined, frameMax)
 
     await eventually(async () => {
-      expect(connection.currentFrameMax).lte(frameMax)
+      expect(client.currentFrameMax).lte(frameMax)
       expect(await rabbit.getConnections()).lengthOf(1)
     }, 5000)
     try {
-      await connection.close()
+      await client.close()
       await rabbit.closeAllConnections()
     } catch (e) {}
   }).timeout(10000)

--- a/test/e2e/connection_closed_listener.test.ts
+++ b/test/e2e/connection_closed_listener.test.ts
@@ -1,0 +1,75 @@
+import { expect, spy } from "chai"
+import { Client } from "../../src"
+import { createClient } from "../support/fake_data"
+import { Rabbit } from "../support/rabbit"
+import { username, password, eventually, always } from "../support/util"
+import { randomUUID } from "crypto"
+import { Offset } from "../../src/requests/subscribe_request"
+describe("connection closed callback", () => {
+  let client: Client | undefined = undefined
+  const rabbit = new Rabbit(username, password)
+  let spySandbox: ChaiSpies.Sandbox | null = null
+  let streamName: string = ""
+  const publisherRef = "the-publisher"
+  const consumerRef = "the-consumer"
+
+  beforeEach(async () => {
+    spySandbox = spy.sandbox()
+    streamName = `my-stream-${randomUUID()}`
+    await rabbit.createStream(streamName)
+  })
+
+  afterEach(async () => {
+    spySandbox?.restore()
+    try {
+      await client?.close()
+      await rabbit.deleteStream(streamName)
+      await rabbit.closeAllConnections()
+      await rabbit.deleteAllQueues({ match: /my-stream-/ })
+    } catch (e) {}
+
+    try {
+      await rabbit.closeAllConnections()
+    } catch (e) {}
+  })
+
+  it.only("is invoked after close operation", async () => {
+    const listener = (_hasError: boolean) => {}
+    const listenerSpy = spy(listener)
+    client = await createClient(username, password, { connection_closed: listenerSpy })
+    await client.close()
+
+    await eventually(() => {
+      expect(listenerSpy).to.have.been.called
+    }, 1000)
+  }).timeout(5000)
+
+  it.only("is invoked only on locator socket event", async () => {
+    const listener = (_hasError: boolean) => {}
+    const listenerSpy = spy(listener)
+    client = await createClient(username, password, { connection_closed: listenerSpy })
+    await client.declarePublisher({ stream: streamName, publisherRef })
+    await client.declareConsumer({ stream: streamName, consumerRef, offset: Offset.first() }, (_msg) => {})
+    await client.close()
+
+    await always(() => {
+      expect(listenerSpy).to.have.been.called.lt(2)
+    }, 1000)
+  }).timeout(5000)
+
+  it.only("if specified, is called also on producer and consumer socket events", async () => {
+    const listener = (_hasError: boolean) => {}
+    const listenerSpy = spy(listener)
+    client = await createClient(username, password, { connection_closed: listenerSpy })
+    await client.declarePublisher({ stream: streamName, publisherRef, connectionClosedListener: listenerSpy })
+    await client.declareConsumer(
+      { stream: streamName, consumerRef, offset: Offset.first(), connectionClosedListener: listenerSpy },
+      (_msg) => {}
+    )
+    await client.close()
+
+    await eventually(() => {
+      expect(listenerSpy).to.have.been.called.exactly(3)
+    }, 1000)
+  }).timeout(5000)
+})

--- a/test/e2e/credit.test.ts
+++ b/test/e2e/credit.test.ts
@@ -1,25 +1,25 @@
 import { expect } from "chai"
-import { Connection } from "../../src"
+import { Client } from "../../src"
 import { Message } from "../../src/producer"
 import { Offset } from "../../src/requests/subscribe_request"
-import { createConnection, createStreamName } from "../support/fake_data"
+import { createClient, createStreamName } from "../support/fake_data"
 import { Rabbit } from "../support/rabbit"
 import { eventually, password, username } from "../support/util"
 
 describe.skip("credit management", () => {
   const rabbit = new Rabbit(username, password)
   let streamName: string
-  let connection: Connection
+  let client: Client
 
   beforeEach(async () => {
-    connection = await createConnection(username, password)
+    client = await createClient(username, password)
     streamName = createStreamName()
     await rabbit.createStream(streamName)
   })
 
   afterEach(async () => {
     try {
-      await connection.close()
+      await client.close()
       await rabbit.deleteStream(streamName)
       await rabbit.closeAllConnections()
       await rabbit.deleteAllQueues({ match: /my-stream-/ })
@@ -31,12 +31,12 @@ describe.skip("credit management", () => {
     const receivedMessages: Buffer[] = []
     const howMany = 2
     const messages = Array.from(Array(howMany).keys()).map((_) => Buffer.from("hello"))
-    const publisher = await connection.declarePublisher({ stream: streamName })
+    const publisher = await client.declarePublisher({ stream: streamName })
     for (const m of messages) {
       await publisher.send(m)
     }
 
-    await connection.declareConsumer({ stream: streamName, offset: Offset.first() }, (message: Message) =>
+    await client.declareConsumer({ stream: streamName, offset: Offset.first() }, (message: Message) =>
       receivedMessages.push(message.content)
     )
 

--- a/test/e2e/declare_consumer.test.ts
+++ b/test/e2e/declare_consumer.test.ts
@@ -93,7 +93,7 @@ describe("declare consumer", () => {
           console.log(message.content)
         ),
       Error,
-      "Declare Consumer command returned error with code 2 - Stream does not exist"
+      "Stream was not found on any node"
     )
   })
 

--- a/test/e2e/declare_publisher.test.ts
+++ b/test/e2e/declare_publisher.test.ts
@@ -50,7 +50,7 @@ describe("declare publisher", () => {
     await expectToThrowAsync(
       () => createPublisher(nonExistingStreamName, client),
       Error,
-      "Declare Publisher command returned error with code 2 - Stream does not exist"
+      "Stream was not found on any node"
     )
   })
 })

--- a/test/e2e/declare_publisher.test.ts
+++ b/test/e2e/declare_publisher.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai"
-import { Connection } from "../../src"
-import { createConnection, createPublisher, createStreamName } from "../support/fake_data"
+import { Client } from "../../src"
+import { createClient, createPublisher, createStreamName } from "../support/fake_data"
 import { Rabbit } from "../support/rabbit"
 import { eventually, expectToThrowAsync, username, password } from "../support/util"
 
@@ -8,10 +8,10 @@ describe("declare publisher", () => {
   let streamName: string
   let nonExistingStreamName: string
   const rabbit = new Rabbit(username, password)
-  let connection: Connection
+  let client: Client
 
   beforeEach(async () => {
-    connection = await createConnection(username, password)
+    client = await createClient(username, password)
     streamName = createStreamName()
     nonExistingStreamName = createStreamName()
     await rabbit.createStream(streamName)
@@ -19,7 +19,7 @@ describe("declare publisher", () => {
 
   afterEach(async () => {
     try {
-      await connection.close()
+      await client.close()
       await rabbit.deleteStream(streamName)
       await rabbit.closeAllConnections()
       await rabbit.deleteAllQueues({ match: /my-stream-/ })
@@ -27,7 +27,7 @@ describe("declare publisher", () => {
   })
 
   it("declaring a publisher on an existing stream - the publisher should be created", async () => {
-    const producer = await createPublisher(streamName, connection)
+    const producer = await createPublisher(streamName, client)
 
     await eventually(async () => {
       expect(await rabbit.returnPublishers(streamName))
@@ -37,7 +37,7 @@ describe("declare publisher", () => {
   }).timeout(10000)
 
   it("declaring a publisher on an existing stream with no publisherRef - the publisher should be created", async () => {
-    const producer = await createPublisher(streamName, connection)
+    const producer = await createPublisher(streamName, client)
 
     await eventually(async () => {
       expect(await rabbit.returnPublishers(streamName))
@@ -48,7 +48,7 @@ describe("declare publisher", () => {
 
   it("declaring a publisher on a non-existing stream should raise an error", async () => {
     await expectToThrowAsync(
-      () => createPublisher(nonExistingStreamName, connection),
+      () => createPublisher(nonExistingStreamName, client),
       Error,
       "Declare Publisher command returned error with code 2 - Stream does not exist"
     )

--- a/test/e2e/metadata_query.test.ts
+++ b/test/e2e/metadata_query.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai"
-import { Connection } from "../../src"
-import { createConnection, createStreamName } from "../support/fake_data"
+import { Client } from "../../src"
+import { createClient, createStreamName } from "../support/fake_data"
 import { Rabbit } from "../support/rabbit"
 import { username, password } from "../support/util"
 import { Broker } from "../../src/responses/metadata_response"
@@ -9,7 +9,7 @@ describe("query metadata", () => {
   let streamName: string
   let nonExistingStreamName: string
   const rabbit = new Rabbit(username, password)
-  let connection: Connection
+  let client: Client
   const RABBIT_TESTING_NODES: Broker[] = [
     {
       host: "localhost",
@@ -24,7 +24,7 @@ describe("query metadata", () => {
   ]
 
   beforeEach(async () => {
-    connection = await createConnection(username, password)
+    client = await createClient(username, password)
     streamName = createStreamName()
     nonExistingStreamName = createStreamName()
     await rabbit.createStream(streamName)
@@ -32,7 +32,7 @@ describe("query metadata", () => {
 
   afterEach(async () => {
     try {
-      await connection.close()
+      await client.close()
       await rabbit.deleteStream(streamName)
       await rabbit.closeAllConnections()
       await rabbit.deleteAllQueues({ match: /my-stream-/ })
@@ -42,18 +42,18 @@ describe("query metadata", () => {
   })
 
   it("query the metadata - the response gets parsed correctly and no exception is thrown", async () => {
-    await connection.queryMetadata({ streams: [streamName] })
+    await client.queryMetadata({ streams: [streamName] })
   })
 
   it("query the metadata - the server should return streamMetaData", async () => {
-    const [streamInfo] = await connection.queryMetadata({ streams: [streamName] })
+    const [streamInfo] = await client.queryMetadata({ streams: [streamName] })
 
     expect(streamInfo).to.exist
     expect(streamInfo.streamName).to.eql(streamName)
   })
 
   it("query the metadata - on a non-existing stream the leader or replicas should not be defined", async () => {
-    const [streamInfo] = await connection.queryMetadata({ streams: [nonExistingStreamName] })
+    const [streamInfo] = await client.queryMetadata({ streams: [nonExistingStreamName] })
 
     expect(streamInfo.streamName).to.eql(nonExistingStreamName)
     expect(streamInfo.leader).not.to.exist
@@ -61,7 +61,7 @@ describe("query metadata", () => {
   })
 
   it("querying the metadata - on an existing stream on a single node", async () => {
-    const [streamInfo] = await connection.queryMetadata({ streams: [streamName] })
+    const [streamInfo] = await client.queryMetadata({ streams: [streamName] })
 
     expect(streamInfo.streamName).to.eql(streamName)
     expect(streamInfo.responseCode).to.eql(1)
@@ -73,7 +73,7 @@ describe("query metadata", () => {
     const secondStreamName = createStreamName()
     await rabbit.createStream(secondStreamName)
 
-    const res = await connection.queryMetadata({ streams: [streamName, secondStreamName] })
+    const res = await client.queryMetadata({ streams: [streamName, secondStreamName] })
     await rabbit.deleteStream(secondStreamName)
 
     const firstStreamInfo = res.find((i) => i.streamName === streamName)

--- a/test/e2e/metadata_update.test.ts
+++ b/test/e2e/metadata_update.test.ts
@@ -1,13 +1,13 @@
 import { expect } from "chai"
-import { Connection, ListenersParams } from "../../src"
+import { Client, ListenersParams } from "../../src"
 import { MetadataUpdateResponse } from "../../src/responses/metadata_update_response"
-import { createConnection, createPublisher, createStreamName } from "../support/fake_data"
+import { createClient, createPublisher, createStreamName } from "../support/fake_data"
 import { Rabbit } from "../support/rabbit"
 import { eventually, username, password } from "../support/util"
 
 describe("update the metadata from the server", () => {
   const rabbit = new Rabbit(username, password)
-  let connection: Connection
+  let client: Client
   let streamName: string
   const metadataUpdateResponses: MetadataUpdateResponse[] = []
 
@@ -16,14 +16,14 @@ describe("update the metadata from the server", () => {
     const listeners: ListenersParams = {
       metadata_update: (data) => metadataUpdateResponses.push(data),
     }
-    connection = await createConnection(username, password, listeners)
+    client = await createClient(username, password, listeners)
     streamName = createStreamName()
     await rabbit.createStream(streamName)
   })
 
   afterEach(async () => {
     try {
-      await connection.close()
+      await client.close()
       await rabbit.deleteStream(streamName)
       await rabbit.closeAllConnections()
       await rabbit.deleteAllQueues({ match: /my-stream-/ })
@@ -31,15 +31,15 @@ describe("update the metadata from the server", () => {
   })
 
   it("when delete stream we receive a metadataUpdate", async () => {
-    await createPublisher(streamName, connection)
+    await createPublisher(streamName, client)
     await rabbit.deleteStream(streamName)
     await eventually(async () => expect(metadataUpdateResponses.length).greaterThanOrEqual(1), 10000)
   }).timeout(10000)
 
   it("when delete stream we receive a metadataUpdate registering after creation", async () => {
     let called = 0
-    await createPublisher(streamName, connection)
-    connection.on("metadata_update", (_data: MetadataUpdateResponse) => called++)
+    await createPublisher(streamName, client)
+    client.on("metadata_update", (_data: MetadataUpdateResponse) => called++)
 
     await rabbit.deleteStream(streamName)
 

--- a/test/e2e/metadata_update.test.ts
+++ b/test/e2e/metadata_update.test.ts
@@ -38,8 +38,8 @@ describe("update the metadata from the server", () => {
 
   it("when delete stream we receive a metadataUpdate registering after creation", async () => {
     let called = 0
-    await createPublisher(streamName, client)
-    client.on("metadata_update", (_data: MetadataUpdateResponse) => called++)
+    const publisher = await createPublisher(streamName, client)
+    publisher.on("metadata_update", (_data: MetadataUpdateResponse) => called++)
 
     await rabbit.deleteStream(streamName)
 

--- a/test/e2e/offset.test.ts
+++ b/test/e2e/offset.test.ts
@@ -1,23 +1,23 @@
 import { expect } from "chai"
-import { Connection } from "../../src"
+import { Client } from "../../src"
 import { Message } from "../../src/producer"
 import { Offset } from "../../src/requests/subscribe_request"
 import { Rabbit } from "../support/rabbit"
 import { eventually, expectToThrowAsync, password, username } from "../support/util"
-import { createConnection } from "../support/fake_data"
+import { createClient } from "../support/fake_data"
 
 describe("offset", () => {
   const rabbit = new Rabbit(username, password)
   const testStreamName = "test-stream"
-  let connection: Connection
+  let client: Client
 
   beforeEach(async () => {
     await rabbit.createStream(testStreamName)
-    connection = await createConnection(username, password)
+    client = await createClient(username, password)
   })
 
   afterEach(async () => {
-    await connection.close()
+    await client.close()
     try {
       await rabbit.deleteStream(testStreamName)
     } catch (e) {}
@@ -26,14 +26,14 @@ describe("offset", () => {
   describe("store", () => {
     it("saving the store offset of a stream correctly", async () => {
       let offset: bigint = 0n
-      const consumer = await connection.declareConsumer(
+      const consumer = await client.declareConsumer(
         { stream: testStreamName, consumerRef: "my consumer", offset: Offset.next() },
         async (message: Message) => {
           await consumer.storeOffset(message.offset!)
           offset = message.offset!
         }
       )
-      const publisher = await connection.declarePublisher({ stream: testStreamName })
+      const publisher = await client.declarePublisher({ stream: testStreamName })
 
       await publisher.send(Buffer.from("hello"))
       await publisher.send(Buffer.from("world"))
@@ -45,7 +45,7 @@ describe("offset", () => {
     }).timeout(10000)
 
     it("declaring a consumer without consumerRef and saving the store offset should rise an error", async () => {
-      const consumer = await connection.declareConsumer(
+      const consumer = await client.declareConsumer(
         { stream: testStreamName, offset: Offset.first() },
         (_message: Message) => {
           return
@@ -62,14 +62,14 @@ describe("offset", () => {
   describe("query", () => {
     it("the consumer is able to track the offset of the stream through queryOffset method", async () => {
       let offset: bigint = 0n
-      const consumer = await connection.declareConsumer(
+      const consumer = await client.declareConsumer(
         { stream: testStreamName, offset: Offset.next(), consumerRef: "my_consumer" },
         async (message: Message) => {
           await consumer.storeOffset(message.offset!)
           offset = message.offset!
         }
       )
-      const publisher = await connection.declarePublisher({ stream: testStreamName })
+      const publisher = await client.declarePublisher({ stream: testStreamName })
 
       await publisher.send(Buffer.from("hello"))
       await publisher.send(Buffer.from("world"))
@@ -81,7 +81,7 @@ describe("offset", () => {
     }).timeout(10000)
 
     it("declaring a consumer without consumerRef and querying for the offset should rise an error", async () => {
-      const consumer = await connection.declareConsumer(
+      const consumer = await client.declareConsumer(
         { stream: testStreamName, offset: Offset.first() },
         (_message: Message) => {
           return
@@ -95,7 +95,7 @@ describe("offset", () => {
     })
 
     it("query offset is able to raise an error if the stream is closed", async () => {
-      const consumer = await connection.declareConsumer(
+      const consumer = await client.declareConsumer(
         { stream: testStreamName, offset: Offset.first(), consumerRef: "my_consumer" },
         (_message: Message) => {
           return

--- a/test/e2e/publish_confirm.test.ts
+++ b/test/e2e/publish_confirm.test.ts
@@ -18,7 +18,7 @@ describe("publish a message and get confirmation", () => {
     await rabbit.createStream(stream)
     publishResponses.splice(0)
   })
-  afterEach(() => client.close())
+  afterEach(async () => await client.close())
   afterEach(() => rabbit.closeAllConnections())
 
   it("after the server replies with a confirm, the confirm callback is invoked", async () => {
@@ -41,7 +41,7 @@ describe("publish a message and get confirmation", () => {
     await eventually(async () => expect((await rabbit.getQueueInfo(stream)).messages).eql(1), 10000)
     const lastPublishingId = await publisher.getLastPublishingId()
     expect(publishResponses).eql([{ error: null, ids: [lastPublishingId] }])
-  }).timeout(10000)
+  }).timeout(12000)
 
   it("after the server replies with an error, the error callback is invoked with an error", async () => {
     const publisher = await client.declarePublisher({ stream, publisherRef })

--- a/test/e2e/query_metadata.test.ts
+++ b/test/e2e/query_metadata.test.ts
@@ -1,44 +1,16 @@
 import { expect } from "chai"
 import { Client } from "../../src"
+import { getTestNodesFromEnv } from "../../src/util"
 import { createClient, createStreamName } from "../support/fake_data"
 import { Rabbit } from "../support/rabbit"
-import { username, password } from "../support/util"
-import { Broker } from "../../src/responses/metadata_response"
+import { password, username } from "../support/util"
 
 describe("query metadata", () => {
   let streamName: string
   let nonExistingStreamName: string
   const rabbit = new Rabbit(username, password)
   let client: Client
-  const RABBIT_TESTING_NODES: Broker[] = [
-    {
-      host: "localhost",
-      port: 5552,
-      reference: 0,
-    },
-    {
-      host: "rabbitmq",
-      port: 5552,
-      reference: 0,
-    },
-    // tests with cluster
-    {
-      host: "node0",
-      port: 5562,
-      reference: 0,
-    },
-    {
-      host: "node1",
-      port: 5572,
-      reference: 1,
-    },
-    {
-      host: "node2",
-      port: 5582,
-      reference: 2,
-    },
-  ]
-
+  const nodes = getTestNodesFromEnv()
   beforeEach(async () => {
     client = await createClient(username, password)
     streamName = createStreamName()
@@ -81,7 +53,7 @@ describe("query metadata", () => {
 
     expect(streamInfo.streamName).to.eql(streamName)
     expect(streamInfo.responseCode).to.eql(1)
-    expect(streamInfo.leader).to.be.deep.oneOf(RABBIT_TESTING_NODES)
+    expect({ host: streamInfo.leader?.host, port: streamInfo.leader?.port }).to.be.deep.oneOf(nodes)
   })
 
   it("querying the metadata - query for multiple streams", async () => {
@@ -96,10 +68,10 @@ describe("query metadata", () => {
     expect(firstStreamInfo).to.exist
     expect(firstStreamInfo!.streamName).to.eql(streamName)
     expect(firstStreamInfo!.responseCode).to.eql(1)
-    expect(firstStreamInfo!.leader).to.be.deep.oneOf(RABBIT_TESTING_NODES)
+    expect({ host: firstStreamInfo!.leader?.host, port: firstStreamInfo!.leader?.port }).to.be.deep.oneOf(nodes)
     expect(secondStreamInfo).to.exist
     expect(secondStreamInfo!.streamName).to.eql(secondStreamName)
     expect(secondStreamInfo!.responseCode).to.eql(1)
-    expect(secondStreamInfo!.leader).to.be.deep.oneOf(RABBIT_TESTING_NODES)
+    expect({ host: secondStreamInfo!.leader?.host, port: secondStreamInfo!.leader?.port }).to.be.deep.oneOf(nodes)
   })
 })

--- a/test/e2e/query_metadata.test.ts
+++ b/test/e2e/query_metadata.test.ts
@@ -21,6 +21,22 @@ describe("query metadata", () => {
       port: 5552,
       reference: 0,
     },
+    // tests with cluster
+    {
+      host: "node0",
+      port: 5562,
+      reference: 0,
+    },
+    {
+      host: "node1",
+      port: 5572,
+      reference: 1,
+    },
+    {
+      host: "node2",
+      port: 5582,
+      reference: 2,
+    },
   ]
 
   beforeEach(async () => {
@@ -66,7 +82,6 @@ describe("query metadata", () => {
     expect(streamInfo.streamName).to.eql(streamName)
     expect(streamInfo.responseCode).to.eql(1)
     expect(streamInfo.leader).to.be.deep.oneOf(RABBIT_TESTING_NODES)
-    expect(streamInfo.replicas).to.have.lengthOf(0)
   })
 
   it("querying the metadata - query for multiple streams", async () => {
@@ -82,11 +97,9 @@ describe("query metadata", () => {
     expect(firstStreamInfo!.streamName).to.eql(streamName)
     expect(firstStreamInfo!.responseCode).to.eql(1)
     expect(firstStreamInfo!.leader).to.be.deep.oneOf(RABBIT_TESTING_NODES)
-    expect(firstStreamInfo!.replicas).to.have.lengthOf(0)
     expect(secondStreamInfo).to.exist
     expect(secondStreamInfo!.streamName).to.eql(secondStreamName)
     expect(secondStreamInfo!.responseCode).to.eql(1)
     expect(secondStreamInfo!.leader).to.be.deep.oneOf(RABBIT_TESTING_NODES)
-    expect(secondStreamInfo!.replicas).to.have.lengthOf(0)
   })
 })

--- a/test/e2e/sub_entry_consume.test.ts
+++ b/test/e2e/sub_entry_consume.test.ts
@@ -1,9 +1,9 @@
 import { expect } from "chai"
-import { Connection } from "../../src"
+import { Client } from "../../src"
 import { Consumer } from "../../src/consumer"
 import { Message, Producer } from "../../src/producer"
 import { Offset } from "../../src/requests/subscribe_request"
-import { createConnection, createPublisher, createStreamName } from "../support/fake_data"
+import { createClient, createPublisher, createStreamName } from "../support/fake_data"
 import { Rabbit } from "../support/rabbit"
 import { eventually, password, username } from "../support/util"
 import { range } from "../../src/util"
@@ -11,21 +11,21 @@ import { CompressionType } from "../../src/compression"
 
 describe("consume a batch of messages", () => {
   const rabbit = new Rabbit(username, password)
-  let connection: Connection
+  let client: Client
   let streamName: string
   let publisher: Producer
   let consumer: Consumer | undefined
 
   beforeEach(async () => {
-    connection = await createConnection(username, password)
+    client = await createClient(username, password)
     streamName = createStreamName()
     await rabbit.createStream(streamName)
-    publisher = await createPublisher(streamName, connection)
+    publisher = await createPublisher(streamName, client)
   })
 
   afterEach(async () => {
     try {
-      await connection.close()
+      await client.close()
       await rabbit.deleteStream(streamName)
       await rabbit.closeAllConnections()
       await rabbit.deleteAllQueues({ match: /my-stream-/ })
@@ -35,7 +35,7 @@ describe("consume a batch of messages", () => {
 
   it("consuming a batch of messages without compression - should not raise error", async () => {
     const receivedMessages = []
-    consumer = await connection.declareConsumer({ stream: streamName, offset: Offset.first() }, (m: Message) =>
+    consumer = await client.declareConsumer({ stream: streamName, offset: Offset.first() }, (m: Message) =>
       receivedMessages.push(m)
     )
     const messages = [
@@ -51,7 +51,7 @@ describe("consume a batch of messages", () => {
 
   it("consume a batch of messages without compression - receive the same number of messages", async () => {
     const receivedMessages = []
-    consumer = await connection.declareConsumer({ stream: streamName, offset: Offset.first() }, (m: Message) =>
+    consumer = await client.declareConsumer({ stream: streamName, offset: Offset.first() }, (m: Message) =>
       receivedMessages.push(m)
     )
     const messages = [
@@ -71,7 +71,7 @@ describe("consume a batch of messages", () => {
 
   it("consume a batch of messages without compression - each received message contains the one that was sent", async () => {
     const receivedMessages: Message[] = []
-    consumer = await connection.declareConsumer({ stream: streamName, offset: Offset.first() }, (m: Message) =>
+    consumer = await client.declareConsumer({ stream: streamName, offset: Offset.first() }, (m: Message) =>
       receivedMessages.push(m)
     )
     const messageContents = range(5).map((_, i) => `Ciao${i}`)
@@ -87,7 +87,7 @@ describe("consume a batch of messages", () => {
 
   it("consuming a batch of messages with compression should not raise error", async () => {
     const receivedMessages = []
-    consumer = await connection.declareConsumer({ stream: streamName, offset: Offset.first() }, (m: Message) =>
+    consumer = await client.declareConsumer({ stream: streamName, offset: Offset.first() }, (m: Message) =>
       receivedMessages.push(m)
     )
     const messages = [
@@ -103,7 +103,7 @@ describe("consume a batch of messages", () => {
 
   it("consume a batch of messages with compression - receive the same number of messages", async () => {
     const receivedMessages = []
-    consumer = await connection.declareConsumer({ stream: streamName, offset: Offset.first() }, (m: Message) =>
+    consumer = await client.declareConsumer({ stream: streamName, offset: Offset.first() }, (m: Message) =>
       receivedMessages.push(m)
     )
     const messages = [
@@ -123,7 +123,7 @@ describe("consume a batch of messages", () => {
 
   it("consume a batch of messages with compression - each received message contains the one that was sent", async () => {
     const receivedMessages: Message[] = []
-    consumer = await connection.declareConsumer({ stream: streamName, offset: Offset.first() }, (m: Message) =>
+    consumer = await client.declareConsumer({ stream: streamName, offset: Offset.first() }, (m: Message) =>
       receivedMessages.push(m)
     )
     const messageContents = range(5).map((_, i) => `Ciao${i}`)

--- a/test/e2e/sub_entry_publish.test.ts
+++ b/test/e2e/sub_entry_publish.test.ts
@@ -1,27 +1,27 @@
 import { expect } from "chai"
-import { Connection } from "../../src"
+import { Client } from "../../src"
 import { Producer } from "../../src/producer"
-import { createConnection, createPublisher, createStreamName } from "../support/fake_data"
+import { createClient, createPublisher, createStreamName } from "../support/fake_data"
 import { Rabbit } from "../support/rabbit"
 import { eventually, username, password } from "../support/util"
 import { CompressionType } from "../../src/compression"
 
 describe("publish a batch of messages", () => {
   const rabbit = new Rabbit(username, password)
-  let connection: Connection
+  let client: Client
   let streamName: string
   let publisher: Producer
 
   beforeEach(async () => {
-    connection = await createConnection(username, password)
+    client = await createClient(username, password)
     streamName = createStreamName()
     await rabbit.createStream(streamName)
-    publisher = await createPublisher(streamName, connection)
+    publisher = await createPublisher(streamName, client)
   })
 
   afterEach(async () => {
     try {
-      await connection.close()
+      await client.close()
       await rabbit.deleteStream(streamName)
       await rabbit.closeAllConnections()
       await rabbit.deleteAllQueues({ match: /my-stream-/ })

--- a/test/e2e/subscribe.test.ts
+++ b/test/e2e/subscribe.test.ts
@@ -1,9 +1,9 @@
 import { expect } from "chai"
+import { Client } from "../../src"
 import { Offset } from "../../src/requests/subscribe_request"
 import { createClient, createStreamName } from "../support/fake_data"
 import { Rabbit } from "../support/rabbit"
-import { eventually, username, password } from "../support/util"
-import { Client } from "../../src"
+import { eventually, password, username } from "../support/util"
 
 describe("subscribe", () => {
   const rabbit = new Rabbit(username, password)
@@ -26,66 +26,66 @@ describe("subscribe", () => {
   })
 
   it("subscribe to next message", async () => {
-    const res = await client.subscribe({
-      subscriptionId: 1,
-      stream: streamName,
-      offset: Offset.next(),
-      credit: 0,
-    })
-
     await eventually(async () => {
+      const res = await client.subscribe({
+        subscriptionId: 1,
+        stream: streamName,
+        offset: Offset.next(),
+        credit: 0,
+      })
+
       expect(res.ok).eql(true)
     }, 5000)
   }).timeout(10000)
 
   it("subscribe to first message", async () => {
-    const res = await client.subscribe({
-      subscriptionId: 2,
-      stream: streamName,
-      offset: Offset.first(),
-      credit: 0,
-    })
-
     await eventually(async () => {
+      const res = await client.subscribe({
+        subscriptionId: 2,
+        stream: streamName,
+        offset: Offset.first(),
+        credit: 0,
+      })
+
       expect(res.ok).eql(true)
     }, 5000)
   }).timeout(10000)
 
   it("subscribe to last message", async () => {
-    const res = await client.subscribe({
-      subscriptionId: 3,
-      stream: streamName,
-      offset: Offset.last(),
-      credit: 0,
-    })
-
     await eventually(async () => {
+      const res = await client.subscribe({
+        subscriptionId: 3,
+        stream: streamName,
+        offset: Offset.last(),
+        credit: 0,
+      })
+
       expect(res.ok).eql(true)
     }, 5000)
   }).timeout(10000)
 
   it("subscribe to offset message", async () => {
-    const res = await client.subscribe({
-      subscriptionId: 4,
-      stream: streamName,
-      offset: Offset.offset(BigInt(1)),
-      credit: 0,
-    })
-
     await eventually(async () => {
+      const res = await client.subscribe({
+        subscriptionId: 4,
+        stream: streamName,
+        offset: Offset.offset(BigInt(1)),
+        credit: 0,
+      })
+
       expect(res.ok).eql(true)
     }, 5000)
   }).timeout(10000)
 
   it("subscribe to date message", async () => {
-    const res = await client.subscribe({
-      subscriptionId: 5,
-      stream: streamName,
-      offset: Offset.timestamp(new Date()),
-      credit: 0,
-    })
-
     await eventually(async () => {
+      const res = await client.subscribe({
+        subscriptionId: 5,
+        stream: streamName,
+        offset: Offset.timestamp(new Date()),
+        credit: 0,
+      })
+
       expect(res.ok).eql(true)
     }, 5000)
   }).timeout(10000)

--- a/test/e2e/subscribe.test.ts
+++ b/test/e2e/subscribe.test.ts
@@ -1,24 +1,24 @@
 import { expect } from "chai"
 import { Offset } from "../../src/requests/subscribe_request"
-import { createConnection, createStreamName } from "../support/fake_data"
+import { createClient, createStreamName } from "../support/fake_data"
 import { Rabbit } from "../support/rabbit"
 import { eventually, username, password } from "../support/util"
-import { Connection } from "../../src"
+import { Client } from "../../src"
 
 describe("subscribe", () => {
   const rabbit = new Rabbit(username, password)
   let streamName: string
-  let connection: Connection
+  let client: Client
 
   beforeEach(async () => {
-    connection = await createConnection(username, password)
+    client = await createClient(username, password)
     streamName = createStreamName()
     await rabbit.createStream(streamName)
   })
 
   afterEach(async () => {
     try {
-      await connection.close()
+      await client.close()
       await rabbit.deleteStream(streamName)
       await rabbit.closeAllConnections()
       await rabbit.deleteAllQueues({ match: /my-stream-/ })
@@ -26,7 +26,7 @@ describe("subscribe", () => {
   })
 
   it("subscribe to next message", async () => {
-    const res = await connection.subscribe({
+    const res = await client.subscribe({
       subscriptionId: 1,
       stream: streamName,
       offset: Offset.next(),
@@ -39,7 +39,7 @@ describe("subscribe", () => {
   }).timeout(10000)
 
   it("subscribe to first message", async () => {
-    const res = await connection.subscribe({
+    const res = await client.subscribe({
       subscriptionId: 2,
       stream: streamName,
       offset: Offset.first(),
@@ -52,7 +52,7 @@ describe("subscribe", () => {
   }).timeout(10000)
 
   it("subscribe to last message", async () => {
-    const res = await connection.subscribe({
+    const res = await client.subscribe({
       subscriptionId: 3,
       stream: streamName,
       offset: Offset.last(),
@@ -65,7 +65,7 @@ describe("subscribe", () => {
   }).timeout(10000)
 
   it("subscribe to offset message", async () => {
-    const res = await connection.subscribe({
+    const res = await client.subscribe({
       subscriptionId: 4,
       stream: streamName,
       offset: Offset.offset(BigInt(1)),
@@ -78,7 +78,7 @@ describe("subscribe", () => {
   }).timeout(10000)
 
   it("subscribe to date message", async () => {
-    const res = await connection.subscribe({
+    const res = await client.subscribe({
       subscriptionId: 5,
       stream: streamName,
       offset: Offset.timestamp(new Date()),

--- a/test/support/fake_data.ts
+++ b/test/support/fake_data.ts
@@ -1,7 +1,9 @@
 import { randomUUID } from "crypto"
 import { Client, ListenersParams, connect } from "../../src/client"
-import { MessageProperties } from "../../src/producer"
+import { MessageProperties, Producer } from "../../src/producer"
 import { BufferSizeSettings } from "../../src/requests/request"
+import { Offset } from "../../src/requests/subscribe_request"
+import { Consumer } from "../../src"
 
 export function createProperties(): MessageProperties {
   return {
@@ -21,11 +23,11 @@ export function createProperties(): MessageProperties {
   }
 }
 
-export function createStreamName() {
+export function createStreamName(): string {
   return `my-stream-${randomUUID()}`
 }
 
-export async function createPublisher(streamName: string, client: Client) {
+export async function createPublisher(streamName: string, client: Client): Promise<Producer> {
   const publisher = await client.declarePublisher({
     stream: streamName,
     publisherRef: `my-publisher-${randomUUID()}`,
@@ -33,13 +35,24 @@ export async function createPublisher(streamName: string, client: Client) {
   return publisher
 }
 
-export function createClient(
+export async function createConsumer(streamName: string, client: Client): Promise<Consumer> {
+  const id = randomUUID()
+  const consumer = await client.declareConsumer(
+    { stream: streamName, offset: Offset.first(), consumerRef: `my-consumer-${id}` },
+    () => {
+      console.log(`Test consumer with id ${id} received a message`)
+    }
+  )
+  return consumer
+}
+
+export async function createClient(
   username: string,
   password: string,
   listeners?: ListenersParams,
   frameMax?: number,
   bufferSizeSettings?: BufferSizeSettings
-) {
+): Promise<Client> {
   return connect({
     hostname: "localhost",
     port: 5552,

--- a/test/support/fake_data.ts
+++ b/test/support/fake_data.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "crypto"
-import { Connection, ListenersParams, connect } from "../../src/connection"
+import { Client, ListenersParams, connect } from "../../src/client"
 import { MessageProperties } from "../../src/producer"
 import { BufferSizeSettings } from "../../src/requests/request"
 
@@ -25,15 +25,15 @@ export function createStreamName() {
   return `my-stream-${randomUUID()}`
 }
 
-export async function createPublisher(streamName: string, connection: Connection) {
-  const publisher = await connection.declarePublisher({
+export async function createPublisher(streamName: string, client: Client) {
+  const publisher = await client.declarePublisher({
     stream: streamName,
     publisherRef: `my-publisher-${randomUUID()}`,
   })
   return publisher
 }
 
-export function createConnection(
+export function createClient(
   username: string,
   password: string,
   listeners?: ListenersParams,

--- a/test/support/fake_data.ts
+++ b/test/support/fake_data.ts
@@ -4,6 +4,7 @@ import { MessageProperties, Producer } from "../../src/producer"
 import { BufferSizeSettings } from "../../src/requests/request"
 import { Offset } from "../../src/requests/subscribe_request"
 import { Consumer } from "../../src"
+import { getTestNodesFromEnv } from "../../src/util"
 
 export function createProperties(): MessageProperties {
   return {
@@ -53,9 +54,10 @@ export async function createClient(
   frameMax?: number,
   bufferSizeSettings?: BufferSizeSettings
 ): Promise<Client> {
+  const [firstNode] = getTestNodesFromEnv()
   return connect({
-    hostname: "localhost",
-    port: 5553,
+    hostname: firstNode.host,
+    port: firstNode.port,
     username,
     password,
     vhost: "/",

--- a/test/support/fake_data.ts
+++ b/test/support/fake_data.ts
@@ -55,7 +55,7 @@ export async function createClient(
 ): Promise<Client> {
   return connect({
     hostname: "localhost",
-    port: 5552,
+    port: 5553,
     username,
     password,
     vhost: "/",

--- a/test/support/rabbit.ts
+++ b/test/support/rabbit.ts
@@ -58,6 +58,7 @@ interface RabbitQueueResponse {
 }
 
 export class Rabbit {
+  private port = process.env.RABBIT_MQ_MANAGEMENT_PORT || 15672
   constructor(private username: string, private password: string) {}
 
   async closeAllConnections(): Promise<void> {
@@ -66,7 +67,7 @@ export class Rabbit {
   }
 
   async closeConnection(name: string) {
-    return got.delete(`http://localhost:15672/api/connections/${name}`, {
+    return got.delete(`http://localhost:${this.port}/api/connections/${name}`, {
       username: this.username,
       password: this.password,
       responseType: "json",
@@ -74,7 +75,7 @@ export class Rabbit {
   }
 
   async getQueueInfo(queue: string): Promise<MessageInfoResponse> {
-    const ret = await got.get<MessageInfoResponse>(`http://localhost:15672/api/queues/%2F/${queue}`, {
+    const ret = await got.get<MessageInfoResponse>(`http://localhost:${this.port}/api/queues/%2F/${queue}`, {
       username: this.username,
       password: this.password,
       responseType: "json",
@@ -84,7 +85,7 @@ export class Rabbit {
 
   async getMessages(queue: string) {
     // I think it's not possible to execute on stream queue
-    const ret = await got.post<unknown>(`http://localhost:15672/api/queues/%2F/${queue}/get`, {
+    const ret = await got.post<unknown>(`http://localhost:${this.port}/api/queues/%2F/${queue}/get`, {
       username: this.username,
       password: this.password,
       responseType: "json",
@@ -94,7 +95,7 @@ export class Rabbit {
   }
 
   async getConnections(): Promise<RabbitConnectionResponse[]> {
-    const ret = await got.get<RabbitConnectionResponse[]>(`http://localhost:15672/api/connections`, {
+    const ret = await got.get<RabbitConnectionResponse[]>(`http://localhost:${this.port}/api/connections`, {
       username: this.username,
       password: this.password,
       responseType: "json",
@@ -103,7 +104,7 @@ export class Rabbit {
   }
 
   createStream(streamName: string) {
-    return got.put<unknown>(`http://localhost:15672/api/queues/%2F/${streamName}`, {
+    return got.put<unknown>(`http://localhost:${this.port}/api/queues/%2F/${streamName}`, {
       body: JSON.stringify({ auto_delete: false, durable: true, arguments: { "x-queue-type": "stream" } }),
       username: this.username,
       password: this.password,
@@ -112,7 +113,7 @@ export class Rabbit {
   }
 
   deleteStream(streamName: string) {
-    return got.delete<unknown>(`http://localhost:15672/api/queues/%2F/${streamName}`, {
+    return got.delete<unknown>(`http://localhost:${this.port}/api/queues/%2F/${streamName}`, {
       username: this.username,
       password: this.password,
     })
@@ -120,7 +121,7 @@ export class Rabbit {
 
   async returnPublishers(streamName: string): Promise<string[]> {
     const resp = await got.get<RabbitPublishersResponse[]>(
-      `http://localhost:15672/api/stream/publishers/%2F/${streamName}`,
+      `http://localhost:${this.port}/api/stream/publishers/%2F/${streamName}`,
       {
         username: this.username,
         password: this.password,
@@ -131,7 +132,7 @@ export class Rabbit {
   }
 
   async returnConsumers(): Promise<string[]> {
-    const resp = await got.get<RabbitConsumersResponse[]>(`http://localhost:15672/api/consumers/%2F/`, {
+    const resp = await got.get<RabbitConsumersResponse[]>(`http://localhost:${this.port}/api/consumers/%2F/`, {
       username: this.username,
       password: this.password,
       responseType: "json",
@@ -141,7 +142,7 @@ export class Rabbit {
 
   async returnConsumersCredits(): Promise<RabbitConsumerCredits[]> {
     const allConsumerCredits: RabbitConsumerCredits[] = []
-    const allConsumersResp = await got.get<RabbitConsumersResponse[]>(`http://localhost:15672/api/consumers`, {
+    const allConsumersResp = await got.get<RabbitConsumersResponse[]>(`http://localhost:${this.port}/api/consumers`, {
       username: "rabbit",
       password: "rabbit",
       responseType: "json",
@@ -150,7 +151,7 @@ export class Rabbit {
     for (const consumerChannelDetail of consumerChannelDetails) {
       const connectionName = consumerChannelDetail.connection_name
       const resp = await got.get<RabbitConnectionDetails[]>(
-        `http://localhost:15672/api/stream/connections/%2F/${connectionName}/consumers`,
+        `http://localhost:${this.port}/api/stream/connections/%2F/${connectionName}/consumers`,
         {
           username: "rabbit",
           password: "rabbit",
@@ -163,7 +164,7 @@ export class Rabbit {
   }
 
   async getQueue(vhost: string = "%2F", name: string): Promise<RabbitQueueResponse> {
-    const ret = await got.get<RabbitQueueResponse>(`http://localhost:15672/api/queues/${vhost}/${name}`, {
+    const ret = await got.get<RabbitQueueResponse>(`http://localhost:${this.port}/api/queues/${vhost}/${name}`, {
       username: this.username,
       password: this.password,
       responseType: "json",
@@ -172,7 +173,7 @@ export class Rabbit {
   }
 
   async deleteQueue(vhost: string = "%2F", name: string): Promise<void> {
-    await got.delete(`http://localhost:15672/api/queues/${vhost}/${name}`, {
+    await got.delete(`http://localhost:${this.port}/api/queues/${vhost}/${name}`, {
       username: this.username,
       password: this.password,
       responseType: "json",
@@ -180,7 +181,7 @@ export class Rabbit {
   }
 
   async createQueue(vhost: string = "%2F", name: string): Promise<RabbitConnectionResponse> {
-    const r = await got.put<RabbitConnectionResponse>(`http://localhost:15672/api/queues/${vhost}/${name}`, {
+    const r = await got.put<RabbitConnectionResponse>(`http://localhost:${this.port}/api/queues/${vhost}/${name}`, {
       json: { arguments: { "x-queue-type": "stream" }, durable: true },
       username: this.username,
       password: this.password,
@@ -190,7 +191,7 @@ export class Rabbit {
   }
 
   async getQueues(): Promise<RabbitQueueResponse[]> {
-    const ret = await got.get<RabbitQueueResponse[]>(`http://localhost:15672/api/queues`, {
+    const ret = await got.get<RabbitQueueResponse[]>(`http://localhost:${this.port}/api/queues`, {
       username: this.username,
       password: this.password,
       responseType: "json",

--- a/test/support/rabbit.ts
+++ b/test/support/rabbit.ts
@@ -1,4 +1,5 @@
 import got from "got"
+import { getTestNodesFromEnv } from "../../src/util"
 interface RabbitConnectionResponse {
   name: string
 }
@@ -59,6 +60,7 @@ interface RabbitQueueResponse {
 
 export class Rabbit {
   private port = process.env.RABBIT_MQ_MANAGEMENT_PORT || 15672
+  private firstNode = getTestNodesFromEnv().shift()!
   constructor(private username: string, private password: string) {}
 
   async closeAllConnections(): Promise<void> {
@@ -67,7 +69,7 @@ export class Rabbit {
   }
 
   async closeConnection(name: string) {
-    return got.delete(`http://localhost:${this.port}/api/connections/${name}`, {
+    return got.delete(`http://${this.firstNode.host}:${this.port}/api/connections/${name}`, {
       username: this.username,
       password: this.password,
       responseType: "json",
@@ -75,17 +77,20 @@ export class Rabbit {
   }
 
   async getQueueInfo(queue: string): Promise<MessageInfoResponse> {
-    const ret = await got.get<MessageInfoResponse>(`http://localhost:${this.port}/api/queues/%2F/${queue}`, {
-      username: this.username,
-      password: this.password,
-      responseType: "json",
-    })
+    const ret = await got.get<MessageInfoResponse>(
+      `http://${this.firstNode.host}:${this.port}/api/queues/%2F/${queue}`,
+      {
+        username: this.username,
+        password: this.password,
+        responseType: "json",
+      }
+    )
     return ret.body
   }
 
   async getMessages(queue: string) {
     // I think it's not possible to execute on stream queue
-    const ret = await got.post<unknown>(`http://localhost:${this.port}/api/queues/%2F/${queue}/get`, {
+    const ret = await got.post<unknown>(`http://${this.firstNode.host}:${this.port}/api/queues/%2F/${queue}/get`, {
       username: this.username,
       password: this.password,
       responseType: "json",
@@ -95,16 +100,19 @@ export class Rabbit {
   }
 
   async getConnections(): Promise<RabbitConnectionResponse[]> {
-    const ret = await got.get<RabbitConnectionResponse[]>(`http://localhost:${this.port}/api/connections`, {
-      username: this.username,
-      password: this.password,
-      responseType: "json",
-    })
+    const ret = await got.get<RabbitConnectionResponse[]>(
+      `http://${this.firstNode.host}:${this.port}/api/connections`,
+      {
+        username: this.username,
+        password: this.password,
+        responseType: "json",
+      }
+    )
     return ret.body
   }
 
   createStream(streamName: string) {
-    return got.put<unknown>(`http://localhost:${this.port}/api/queues/%2F/${streamName}`, {
+    return got.put<unknown>(`http://${this.firstNode.host}:${this.port}/api/queues/%2F/${streamName}`, {
       body: JSON.stringify({ auto_delete: false, durable: true, arguments: { "x-queue-type": "stream" } }),
       username: this.username,
       password: this.password,
@@ -113,7 +121,7 @@ export class Rabbit {
   }
 
   deleteStream(streamName: string) {
-    return got.delete<unknown>(`http://localhost:${this.port}/api/queues/%2F/${streamName}`, {
+    return got.delete<unknown>(`http://${this.firstNode.host}:${this.port}/api/queues/%2F/${streamName}`, {
       username: this.username,
       password: this.password,
     })
@@ -121,7 +129,7 @@ export class Rabbit {
 
   async returnPublishers(streamName: string): Promise<string[]> {
     const resp = await got.get<RabbitPublishersResponse[]>(
-      `http://localhost:${this.port}/api/stream/publishers/%2F/${streamName}`,
+      `http://${this.firstNode.host}:${this.port}/api/stream/publishers/%2F/${streamName}`,
       {
         username: this.username,
         password: this.password,
@@ -132,26 +140,32 @@ export class Rabbit {
   }
 
   async returnConsumers(): Promise<string[]> {
-    const resp = await got.get<RabbitConsumersResponse[]>(`http://localhost:${this.port}/api/consumers/%2F/`, {
-      username: this.username,
-      password: this.password,
-      responseType: "json",
-    })
+    const resp = await got.get<RabbitConsumersResponse[]>(
+      `http://${this.firstNode.host}:${this.port}/api/consumers/%2F/`,
+      {
+        username: this.username,
+        password: this.password,
+        responseType: "json",
+      }
+    )
     return resp.body.map((p) => p.consumer_tag)
   }
 
   async returnConsumersCredits(): Promise<RabbitConsumerCredits[]> {
     const allConsumerCredits: RabbitConsumerCredits[] = []
-    const allConsumersResp = await got.get<RabbitConsumersResponse[]>(`http://localhost:${this.port}/api/consumers`, {
-      username: "rabbit",
-      password: "rabbit",
-      responseType: "json",
-    })
+    const allConsumersResp = await got.get<RabbitConsumersResponse[]>(
+      `http://${this.firstNode.host}:${this.port}/api/consumers`,
+      {
+        username: "rabbit",
+        password: "rabbit",
+        responseType: "json",
+      }
+    )
     const consumerChannelDetails = allConsumersResp.body.map((d) => d.channel_details)
     for (const consumerChannelDetail of consumerChannelDetails) {
       const connectionName = consumerChannelDetail.connection_name
       const resp = await got.get<RabbitConnectionDetails[]>(
-        `http://localhost:${this.port}/api/stream/connections/%2F/${connectionName}/consumers`,
+        `http://${this.firstNode.host}:${this.port}/api/stream/connections/%2F/${connectionName}/consumers`,
         {
           username: "rabbit",
           password: "rabbit",
@@ -164,16 +178,19 @@ export class Rabbit {
   }
 
   async getQueue(vhost: string = "%2F", name: string): Promise<RabbitQueueResponse> {
-    const ret = await got.get<RabbitQueueResponse>(`http://localhost:${this.port}/api/queues/${vhost}/${name}`, {
-      username: this.username,
-      password: this.password,
-      responseType: "json",
-    })
+    const ret = await got.get<RabbitQueueResponse>(
+      `http://${this.firstNode.host}:${this.port}/api/queues/${vhost}/${name}`,
+      {
+        username: this.username,
+        password: this.password,
+        responseType: "json",
+      }
+    )
     return ret.body
   }
 
   async deleteQueue(vhost: string = "%2F", name: string): Promise<void> {
-    await got.delete(`http://localhost:${this.port}/api/queues/${vhost}/${name}`, {
+    await got.delete(`http://${this.firstNode.host}:${this.port}/api/queues/${vhost}/${name}`, {
       username: this.username,
       password: this.password,
       responseType: "json",
@@ -181,17 +198,20 @@ export class Rabbit {
   }
 
   async createQueue(vhost: string = "%2F", name: string): Promise<RabbitConnectionResponse> {
-    const r = await got.put<RabbitConnectionResponse>(`http://localhost:${this.port}/api/queues/${vhost}/${name}`, {
-      json: { arguments: { "x-queue-type": "stream" }, durable: true },
-      username: this.username,
-      password: this.password,
-    })
+    const r = await got.put<RabbitConnectionResponse>(
+      `http://${this.firstNode.host}:${this.port}/api/queues/${vhost}/${name}`,
+      {
+        json: { arguments: { "x-queue-type": "stream" }, durable: true },
+        username: this.username,
+        password: this.password,
+      }
+    )
 
     return r.body
   }
 
   async getQueues(): Promise<RabbitQueueResponse[]> {
-    const ret = await got.get<RabbitQueueResponse[]>(`http://localhost:${this.port}/api/queues`, {
+    const ret = await got.get<RabbitQueueResponse[]>(`http://${this.firstNode.host}:${this.port}/api/queues`, {
       username: this.username,
       password: this.password,
       responseType: "json",

--- a/test/support/util.ts
+++ b/test/support/util.ts
@@ -37,6 +37,22 @@ export function elapsedFrom(from: number): number {
   return Date.now() - from
 }
 
+export async function always(fn: Function, timeout = 1500) {
+  const start = Date.now()
+  while (true) {
+    try {
+      await fn()
+      await wait(5)
+      if (elapsedFrom(start) > timeout) {
+        return
+      }
+    } catch (error) {
+      if (error instanceof AssertionError) throw error
+      expect.fail(error as string)
+    }
+  }
+}
+
 export async function eventually(fn: Function, timeout = 1500) {
   const start = Date.now()
   while (true) {

--- a/test/support/util.ts
+++ b/test/support/util.ts
@@ -9,6 +9,7 @@ import { Properties } from "../../src/amqp10/properties"
 import { Message, MessageApplicationProperties, MessageHeader, MessageProperties } from "../../src/producer"
 import { decodeFormatCode } from "../../src/response_decoder"
 import { DataReader } from "../../src/responses/raw_response"
+import { getTestNodesFromEnv } from "../../src/util"
 
 export function createConsoleLog({ silent, level } = { silent: false, level: "debug" }) {
   return createLogger({
@@ -26,7 +27,11 @@ export function createConsoleLog({ silent, level } = { silent: false, level: "de
   })
 }
 
-const getAmqpConnectionString = (user: string, pwd: string): string => `amqp://${user}:${pwd}@localhost:5555/%2F`
+const getAmqpConnectionString = (user: string, pwd: string): string => {
+  const [firstNode] = getTestNodesFromEnv()
+  const port = process.env.RABBIT_MQ_AMQP_PORT ?? 5672
+  return `amqp://${user}:${pwd}@${firstNode.host}:${port}/%2F`
+}
 
 export function elapsedFrom(from: number): number {
   return Date.now() - from

--- a/test/unit/create_stream.test.ts
+++ b/test/unit/create_stream.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai"
 import { randomUUID } from "crypto"
-import { connect, Connection } from "../../src"
+import { connect, Client } from "../../src"
 import { Rabbit } from "../support/rabbit"
 import { expectToThrowAsync, username, password } from "../support/util"
 
@@ -14,10 +14,10 @@ describe("Stream", () => {
     "x-initial-cluster-size": 42,
     "x-max-length-bytes": 42,
   }
-  let connection: Connection
+  let client: Client
 
   beforeEach(async () => {
-    connection = await connect({
+    client = await connect({
       hostname: "localhost",
       port: 5552,
       username,
@@ -35,7 +35,7 @@ describe("Stream", () => {
   })
   afterEach(async () => {
     try {
-      await connection.close()
+      await client.close()
     } catch (error) {}
   })
 
@@ -43,7 +43,7 @@ describe("Stream", () => {
 
   describe("Create", () => {
     it("Should create a new Stream", async () => {
-      const resp = await connection.createStream({ stream: streamName, arguments: payload })
+      const resp = await client.createStream({ stream: streamName, arguments: payload })
 
       expect(resp).to.be.true
       const result = await rabbit.getQueue("%2F", streamName)
@@ -51,15 +51,15 @@ describe("Stream", () => {
     })
 
     it("Should be idempotent and ignore a duplicate Stream error", async () => {
-      await connection.createStream({ stream: streamName, arguments: payload })
-      const resp = await connection.createStream({ stream: streamName, arguments: payload })
+      await client.createStream({ stream: streamName, arguments: payload })
+      const resp = await client.createStream({ stream: streamName, arguments: payload })
 
       expect(resp).to.be.true
     })
 
     it("Should raise an error if creation goes wrong", async () => {
       await expectToThrowAsync(
-        () => connection.createStream({ stream: "", arguments: payload }),
+        () => client.createStream({ stream: "", arguments: payload }),
         Error,
         "Create Stream command returned error with code 17"
       )

--- a/test/unit/create_stream.test.ts
+++ b/test/unit/create_stream.test.ts
@@ -1,8 +1,9 @@
 import { expect } from "chai"
 import { randomUUID } from "crypto"
-import { connect, Client } from "../../src"
+import { Client } from "../../src"
+import { createClient } from "../support/fake_data"
 import { Rabbit } from "../support/rabbit"
-import { expectToThrowAsync, username, password } from "../support/util"
+import { expectToThrowAsync, password, username } from "../support/util"
 
 describe("Stream", () => {
   const rabbit = new Rabbit(username, password)
@@ -17,15 +18,7 @@ describe("Stream", () => {
   let client: Client
 
   beforeEach(async () => {
-    client = await connect({
-      hostname: "localhost",
-      port: 5552,
-      username,
-      password,
-      vhost: "/",
-      frameMax: 0,
-      heartbeat: 0,
-    })
+    client = await createClient(username, password)
   })
 
   afterEach(async () => {

--- a/test/unit/delete_publisher.test.ts
+++ b/test/unit/delete_publisher.test.ts
@@ -1,34 +1,34 @@
-import { Connection } from "../../src"
+import { Client } from "../../src"
 import { expect } from "chai"
 import { Rabbit } from "../support/rabbit"
 import { randomUUID } from "crypto"
 import { expectToThrowAsync, username, password } from "../support/util"
-import { createConnection } from "../support/fake_data"
+import { createClient } from "../support/fake_data"
 
 describe("DeletePublisher command", () => {
   const rabbit = new Rabbit(username, password)
   const testStreamName = "test-stream"
-  let connection: Connection
+  let client: Client
   let publisherRef: string
 
   beforeEach(async () => {
     publisherRef = randomUUID()
     await rabbit.createStream(testStreamName)
-    connection = await createConnection(username, password)
+    client = await createClient(username, password)
   })
 
   afterEach(async () => {
-    await connection.close()
+    await client.close()
     await rabbit.deleteStream(testStreamName)
   })
 
   it("can delete a publisher", async () => {
-    const publisher = await connection.declarePublisher({ stream: testStreamName, publisherRef })
+    const publisher = await client.declarePublisher({ stream: testStreamName, publisherRef })
     await publisher.send(Buffer.from(`test${randomUUID()}`))
 
     const publisherId = publisher.publisherId
 
-    const deletePublisher = await connection.deletePublisher(Number(publisherId))
+    const deletePublisher = await client.deletePublisher(Number(publisherId))
     expect(deletePublisher).eql(true)
   }).timeout(10000)
 
@@ -36,7 +36,7 @@ describe("DeletePublisher command", () => {
     const nonExistentPublisherId = 42
 
     await expectToThrowAsync(
-      () => connection.deletePublisher(Number(nonExistentPublisherId)),
+      () => client.deletePublisher(Number(nonExistentPublisherId)),
       Error,
       "Delete Publisher command returned error with code 18 - Publisher does not exist"
     )

--- a/test/unit/delete_stream.test.ts
+++ b/test/unit/delete_stream.test.ts
@@ -1,7 +1,8 @@
-import { connect, Client } from "../../src"
 import { expect } from "chai"
+import { Client } from "../../src"
+import { createClient } from "../support/fake_data"
 import { Rabbit } from "../support/rabbit"
-import { expectToThrowAsync, username, password } from "../support/util"
+import { expectToThrowAsync, password, username } from "../support/util"
 
 describe("Delete command", () => {
   const rabbit: Rabbit = new Rabbit(username, password)
@@ -9,15 +10,7 @@ describe("Delete command", () => {
   const queue_name = `queue_${(Math.random() * 10) | 0}`
 
   beforeEach(async () => {
-    client = await connect({
-      hostname: "localhost",
-      port: 5552,
-      username,
-      password,
-      vhost: "/",
-      frameMax: 0,
-      heartbeat: 0,
-    })
+    client = await createClient(username, password)
   })
 
   afterEach(async () => {

--- a/test/unit/delete_stream.test.ts
+++ b/test/unit/delete_stream.test.ts
@@ -1,15 +1,15 @@
-import { connect, Connection } from "../../src"
+import { connect, Client } from "../../src"
 import { expect } from "chai"
 import { Rabbit } from "../support/rabbit"
 import { expectToThrowAsync, username, password } from "../support/util"
 
 describe("Delete command", () => {
   const rabbit: Rabbit = new Rabbit(username, password)
-  let connection: Connection
+  let client: Client
   const queue_name = `queue_${(Math.random() * 10) | 0}`
 
   beforeEach(async () => {
-    connection = await connect({
+    client = await connect({
       hostname: "localhost",
       port: 5552,
       username,
@@ -26,7 +26,7 @@ describe("Delete command", () => {
 
   afterEach(async () => {
     try {
-      await connection.close()
+      await client.close()
     } catch (error) {}
   })
 
@@ -34,7 +34,7 @@ describe("Delete command", () => {
 
   it("delete a nonexisting stream (raises error)", async () => {
     await expectToThrowAsync(
-      () => connection?.deleteStream({ stream: "AAA" }),
+      () => client?.deleteStream({ stream: "AAA" }),
       Error,
       "Delete Stream command returned error with code 2"
     )
@@ -45,7 +45,7 @@ describe("Delete command", () => {
     await rabbit.getQueue("%2F", queue_name)
     let errorOnRetrieveAfterDeletion = null
 
-    const result = await connection?.deleteStream({ stream: queue_name })
+    const result = await client?.deleteStream({ stream: queue_name })
 
     try {
       await rabbit.getQueue("%2F", queue_name)

--- a/test/unit/producer.test.ts
+++ b/test/unit/producer.test.ts
@@ -63,13 +63,14 @@ describe("Producer", () => {
 
     beforeEach(async () => {
       spySandbox = spy.sandbox()
-      writeClient = await createClient(username, password)
+      writeClient = await createClient(username, password, undefined, maxFrameSize)
     })
 
     afterEach(async () => {
       await writeClient!.close()
       spySandbox?.restore()
     })
+
     it("if a message is too big an exception is raised when sending it", async () => {
       const publisher = await writeClient!.declarePublisher({
         stream: testStreamName,

--- a/test/unit/stream_stats.test.ts
+++ b/test/unit/stream_stats.test.ts
@@ -1,34 +1,34 @@
-import { Connection } from "../../src"
+import { Client } from "../../src"
 import { expect } from "chai"
 import { Rabbit } from "../support/rabbit"
 import { randomUUID } from "crypto"
 import { expectToThrowAsync, username, password } from "../support/util"
-import { createConnection } from "../support/fake_data"
+import { createClient } from "../support/fake_data"
 
 describe("StreamStats", () => {
   const rabbit = new Rabbit(username, password)
   const testStreamName = "test-stream"
-  let connection: Connection
+  let client: Client
   let publisherRef: string
 
   beforeEach(async () => {
     publisherRef = randomUUID()
     await rabbit.createStream(testStreamName)
-    connection = await createConnection(username, password)
+    client = await createClient(username, password)
   })
 
   afterEach(async () => {
-    await connection.close()
+    await client.close()
     await rabbit.deleteStream(testStreamName)
   })
 
   it("gets statistics for a stream", async () => {
-    const publisher = await connection.declarePublisher({ stream: testStreamName, publisherRef })
+    const publisher = await client.declarePublisher({ stream: testStreamName, publisherRef })
     for (let i = 0; i < 5; i++) {
       await publisher.send(Buffer.from(`test${randomUUID()}`))
     }
 
-    const stats = await connection.streamStatsRequest(testStreamName)
+    const stats = await client.streamStatsRequest(testStreamName)
 
     expect(stats.committedChunkId).to.be.a("BigInt")
     expect(stats.firstChunkId).to.be.a("BigInt")
@@ -37,7 +37,7 @@ describe("StreamStats", () => {
 
   it("returns an error when the stream does not exist", async () => {
     await expectToThrowAsync(
-      () => connection.streamStatsRequest("stream-does-not-exist"),
+      () => client.streamStatsRequest("stream-does-not-exist"),
       Error,
       "Stream Stats command returned error with code 2 - Stream does not exist"
     )


### PR DESCRIPTION
On socket disconnect, a user-provided function can be called, if specified.

This callback, linked to the underlying socket event, can be specified:
  - for locator clients, among the `listeners` field passed to the `Client.connect` function. Such a callback is specific for the locator connection and is not linked to  connection events related to publisher/consumer instances created from the locator.
  - for publishers and consumers, as a field in the parameters of `declarePublisher` and `declareConsumer`. Such callbacks are specific for the single publisher/consumer.