### PR TITLE
104 disconnect hook (clean)

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -54,6 +54,8 @@ import { UnsubscribeResponse } from "./responses/unsubscribe_response"
 import { DEFAULT_FRAME_MAX, DEFAULT_UNLIMITED_FRAME_MAX, removeFrom, sample } from "./util"
 import { WaitingResponse } from "./waiting_response"
 
+export type ConnectionClosedListener = (hadError: boolean) => void
+
 export class Client {
   private socket: Socket
   private correlationId = 100
@@ -69,6 +71,7 @@ export class Client {
   private readonly bufferSizeSettings: BufferSizeSettings
   private frameMax: number = DEFAULT_FRAME_MAX
   private connectionId: string
+  private connectionClosedListener: ConnectionClosedListener | undefined
 
   private constructor(private readonly logger: Logger, private readonly params: ConnectionParams) {
     if (params.frameMax) this.frameMax = params.frameMax
@@ -85,6 +88,7 @@ export class Client {
     this.decoder = new ResponseDecoder((...args) => this.responseReceived(...args), this.logger)
     this.bufferSizeSettings = params.bufferSizeSettings || {}
     this.connectionId = randomUUID()
+    this.connectionClosedListener = params.listeners?.connection_closed
   }
 
   getCompression(compressionType: CompressionType) {
@@ -140,6 +144,7 @@ export class Client {
       })
       this.socket.on("close", (had_error) => {
         this.logger.info(`Close event on socket, close cloud had_error? ${had_error}`)
+        if (this.connectionClosedListener) this.connectionClosedListener(had_error)
       })
     })
   }
@@ -201,7 +206,7 @@ export class Client {
     const { stream, publisherRef } = params
     const publisherId = this.incPublisherId()
 
-    const client = await this.initNewClient(params.stream, true)
+    const client = await this.initNewClient(params.stream, true, params.connectionClosedListener)
     const res = await client.sendAndWait<DeclarePublisherResponse>(
       new DeclarePublisherRequest({ stream, publisherRef, publisherId })
     )
@@ -241,7 +246,7 @@ export class Client {
 
   public async declareConsumer(params: DeclareConsumerParams, handle: ConsumerFunc): Promise<Consumer> {
     const consumerId = this.incConsumerId()
-    const client = await this.initNewClient(params.stream, false)
+    const client = await this.initNewClient(params.stream, false, params.connectionClosedListener)
     const consumer = new StreamConsumer(addOffsetFilterToHandle(handle, params.offset), {
       client,
       stream: params.stream,
@@ -554,13 +559,22 @@ export class Client {
     return { maxSize: this.frameMax, ...this.bufferSizeSettings }
   }
 
-  private async initNewClient(streamName: string, leader: boolean): Promise<Client> {
+  private async initNewClient(
+    streamName: string,
+    leader: boolean,
+    connectionClosedListener?: ConnectionClosedListener
+  ): Promise<Client> {
     const [metadata] = await this.queryMetadata({ streams: [streamName] })
     const chosenNode = leader ? metadata.leader : sample([metadata.leader, ...(metadata.replicas ?? [])])
     if (!chosenNode) {
       throw new Error(`Stream was not found on any node`)
     }
-    const newClient = await connect({ ...this.params, hostname: chosenNode.host, port: chosenNode.port }, this.logger)
+    const listeners = { ...this.params.listeners, connection_closed: connectionClosedListener }
+    const connectionParams = { ...this.params, listeners: listeners }
+    const newClient = await connect(
+      { ...connectionParams, hostname: chosenNode.host, port: chosenNode.port },
+      this.logger
+    )
     return newClient
   }
 }
@@ -569,6 +583,7 @@ export type ListenersParams = {
   metadata_update?: MetadataUpdateListener
   publish_confirm?: PublishConfirmListener
   publish_error?: PublishErrorListener
+  connection_closed?: ConnectionClosedListener
 }
 
 export interface SSLConnectionParams {
@@ -596,12 +611,14 @@ export interface DeclarePublisherParams {
   publisherRef?: string
   boot?: boolean
   maxChunkLength?: number
+  connectionClosedListener?: ConnectionClosedListener
 }
 
 export interface DeclareConsumerParams {
   stream: string
   consumerRef?: string
   offset: Offset
+  connectionClosedListener?: ConnectionClosedListener
 }
 
 export interface SubscribeParams {

--- a/test/e2e/connection_closed_listener.test.ts
+++ b/test/e2e/connection_closed_listener.test.ts
@@ -33,10 +33,13 @@ describe("connection closed callback", () => {
     } catch (e) {}
   })
 
-  it.only("is invoked after close operation", async () => {
-    const listener = (_hasError: boolean) => {}
+  it("is invoked after close operation", async () => {
+    const listener = (_hasError: boolean) => {
+      return
+    }
     const listenerSpy = spy(listener)
     client = await createClient(username, password, { connection_closed: listenerSpy })
+
     await client.close()
 
     await eventually(() => {
@@ -44,12 +47,17 @@ describe("connection closed callback", () => {
     }, 1000)
   }).timeout(5000)
 
-  it.only("is invoked only on locator socket event", async () => {
-    const listener = (_hasError: boolean) => {}
+  it("is invoked only on locator socket event", async () => {
+    const listener = (_hasError: boolean) => {
+      return
+    }
     const listenerSpy = spy(listener)
     client = await createClient(username, password, { connection_closed: listenerSpy })
     await client.declarePublisher({ stream: streamName, publisherRef })
-    await client.declareConsumer({ stream: streamName, consumerRef, offset: Offset.first() }, (_msg) => {})
+    await client.declareConsumer({ stream: streamName, consumerRef, offset: Offset.first() }, (_msg) => {
+      return
+    })
+
     await client.close()
 
     await always(() => {
@@ -57,15 +65,20 @@ describe("connection closed callback", () => {
     }, 1000)
   }).timeout(5000)
 
-  it.only("if specified, is called also on producer and consumer socket events", async () => {
-    const listener = (_hasError: boolean) => {}
+  it("if specified, is called also on producer and consumer socket events", async () => {
+    const listener = (_hasError: boolean) => {
+      return
+    }
     const listenerSpy = spy(listener)
     client = await createClient(username, password, { connection_closed: listenerSpy })
     await client.declarePublisher({ stream: streamName, publisherRef, connectionClosedListener: listenerSpy })
     await client.declareConsumer(
       { stream: streamName, consumerRef, offset: Offset.first(), connectionClosedListener: listenerSpy },
-      (_msg) => {}
+      (_msg) => {
+        return
+      }
     )
+
     await client.close()
 
     await eventually(() => {

--- a/test/e2e/connection_closed_listener.test.ts
+++ b/test/e2e/connection_closed_listener.test.ts
@@ -1,0 +1,75 @@
+import { expect, spy } from "chai"
+import { Client } from "../../src"
+import { createClient } from "../support/fake_data"
+import { Rabbit } from "../support/rabbit"
+import { username, password, eventually, always } from "../support/util"
+import { randomUUID } from "crypto"
+import { Offset } from "../../src/requests/subscribe_request"
+describe("connection closed callback", () => {
+  let client: Client | undefined = undefined
+  const rabbit = new Rabbit(username, password)
+  let spySandbox: ChaiSpies.Sandbox | null = null
+  let streamName: string = ""
+  const publisherRef = "the-publisher"
+  const consumerRef = "the-consumer"
+
+  beforeEach(async () => {
+    spySandbox = spy.sandbox()
+    streamName = `my-stream-${randomUUID()}`
+    await rabbit.createStream(streamName)
+  })
+
+  afterEach(async () => {
+    spySandbox?.restore()
+    try {
+      await client?.close()
+      await rabbit.deleteStream(streamName)
+      await rabbit.closeAllConnections()
+      await rabbit.deleteAllQueues({ match: /my-stream-/ })
+    } catch (e) {}
+
+    try {
+      await rabbit.closeAllConnections()
+    } catch (e) {}
+  })
+
+  it.only("is invoked after close operation", async () => {
+    const listener = (_hasError: boolean) => {}
+    const listenerSpy = spy(listener)
+    client = await createClient(username, password, { connection_closed: listenerSpy })
+    await client.close()
+
+    await eventually(() => {
+      expect(listenerSpy).to.have.been.called
+    }, 1000)
+  }).timeout(5000)
+
+  it.only("is invoked only on locator socket event", async () => {
+    const listener = (_hasError: boolean) => {}
+    const listenerSpy = spy(listener)
+    client = await createClient(username, password, { connection_closed: listenerSpy })
+    await client.declarePublisher({ stream: streamName, publisherRef })
+    await client.declareConsumer({ stream: streamName, consumerRef, offset: Offset.first() }, (_msg) => {})
+    await client.close()
+
+    await always(() => {
+      expect(listenerSpy).to.have.been.called.lt(2)
+    }, 1000)
+  }).timeout(5000)
+
+  it.only("if specified, is called also on producer and consumer socket events", async () => {
+    const listener = (_hasError: boolean) => {}
+    const listenerSpy = spy(listener)
+    client = await createClient(username, password, { connection_closed: listenerSpy })
+    await client.declarePublisher({ stream: streamName, publisherRef, connectionClosedListener: listenerSpy })
+    await client.declareConsumer(
+      { stream: streamName, consumerRef, offset: Offset.first(), connectionClosedListener: listenerSpy },
+      (_msg) => {}
+    )
+    await client.close()
+
+    await eventually(() => {
+      expect(listenerSpy).to.have.been.called.exactly(3)
+    }, 1000)
+  }).timeout(5000)
+})

--- a/test/support/util.ts
+++ b/test/support/util.ts
@@ -36,6 +36,22 @@ export function elapsedFrom(from: number): number {
   return Date.now() - from
 }
 
+export async function always(fn: Function, timeout = 1500) {
+  const start = Date.now()
+  while (true) {
+    try {
+      await fn()
+      await wait(5)
+      if (elapsedFrom(start) > timeout) {
+        return
+      }
+    } catch (error) {
+      if (error instanceof AssertionError) throw error
+      expect.fail(error as string)
+    }
+  }
+}
+
 export async function eventually(fn: Function, timeout = 1500) {
   const start = Date.now()
   while (true) {


### PR DESCRIPTION
Closes #104 

On socket disconnect, a user-provided function can be called, if specified.

This callback, linked to the underlying socket event, can be specified:

for locator clients, among the listeners field passed to the Client.connect function. Such a callback is specific for the locator connection and is not linked to connection events related to publisher/consumer instances created from the locator.
for publishers and consumers, as a field in the parameters of declarePublisher and declareConsumer. Such callbacks are specific for the single publisher/consumer.