### PR TITLE
feat(super-stream): enable customized consumerRef, offset

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -207,12 +207,16 @@ export class Client {
   }
 
   public async declareSuperStreamConsumer(
-    { superStream }: DeclareSuperStreamConsumerParams,
+    { superStream, offset, consumerRef }: DeclareSuperStreamConsumerParams,
     handle: ConsumerFunc
   ): Promise<SuperStreamConsumer> {
-    const consumerRef = `${superStream}-${randomUUID()}`
     const partitions = await this.queryPartitions({ superStream })
-    return SuperStreamConsumer.create(handle, { locator: this, consumerRef, partitions })
+    return SuperStreamConsumer.create(handle, {
+      locator: this,
+      consumerRef: consumerRef || `${superStream}-${randomUUID()}`,
+      offset: offset || Offset.first(),
+      partitions,
+    })
   }
 
   public async declareSuperStreamPublisher(
@@ -688,6 +692,8 @@ export interface DeclareConsumerParams {
 
 export interface DeclareSuperStreamConsumerParams {
   superStream: string
+  consumerRef?: string
+  offset?: Offset
 }
 
 export interface SubscribeParams {

--- a/src/super_stream_consumer.ts
+++ b/src/super_stream_consumer.ts
@@ -7,6 +7,7 @@ export class SuperStreamConsumer {
   public consumerRef: string
   private locator: Client
   private partitions: string[]
+  private offset: Offset
 
   private constructor(
     readonly handle: ConsumerFunc,
@@ -14,18 +15,20 @@ export class SuperStreamConsumer {
       locator: Client
       partitions: string[]
       consumerRef: string
+      offset: Offset
     }
   ) {
     this.consumerRef = params.consumerRef
     this.locator = params.locator
     this.partitions = params.partitions
+    this.offset = params.offset
   }
 
   async start(): Promise<void> {
     await Promise.all(
       this.partitions.map(async (p) => {
         const partitionConsumer = await this.locator.declareConsumer(
-          { stream: p, consumerRef: this.consumerRef, offset: Offset.first(), singleActive: true },
+          { stream: p, consumerRef: this.consumerRef, offset: this.offset, singleActive: true },
           this.handle
         )
         this.consumers.set(p, partitionConsumer)
@@ -40,6 +43,7 @@ export class SuperStreamConsumer {
       locator: Client
       partitions: string[]
       consumerRef: string
+      offset: Offset
     }
   ): Promise<SuperStreamConsumer> {
     const superStreamConsumer = new SuperStreamConsumer(handle, params)


### PR DESCRIPTION
### ⛔Before
```js
client.declareSuperStreamConsumer(
      {
        superStream: superStreamName
        // consumerRef: "super-stream-[random-uuid]", as default, can not change
        // offset: Offset.first(), as default, can not change
      },
      (message: Message) => {
        // handle message logic
      })
```
### ✅After
```js
client.declareSuperStreamConsumer(
      {
        superStream: superStreamName,
        consumerRef: "consumer-group-name", // defined by user
        offset: Offset.next() // defined by user
      },
      (message: Message) => {
        // handle message logic
      })
```