### PR TITLE
Check if cached connection can support more pub/subs before reusing

### DIFF
--- a/src/connection_pool.ts
+++ b/src/connection_pool.ts
@@ -7,9 +7,9 @@ export class ConnectionPool {
   private static consumerConnectionProxies = new Map<InstanceKey, Connection[]>()
   private static publisherConnectionProxies = new Map<InstanceKey, Connection[]>()
 
-  public static getUsableCachedConnection(leader: boolean, streamName: string, host: string) {
+  public static getUsableCachedConnection(leader: boolean, streamName: string, host: string, index: number) {
     const m = leader ? ConnectionPool.publisherConnectionProxies : ConnectionPool.consumerConnectionProxies
-    const k = ConnectionPool.getCacheKey(streamName, host)
+    const k = ConnectionPool.getCacheKey(streamName, host, index)
     const proxies = m.get(k) || []
     const connection = proxies.at(-1)
     const refCount = connection?.refCount
@@ -18,7 +18,7 @@ export class ConnectionPool {
 
   public static cacheConnection(leader: boolean, streamName: string, host: string, client: Connection) {
     const m = leader ? ConnectionPool.publisherConnectionProxies : ConnectionPool.consumerConnectionProxies
-    const k = ConnectionPool.getCacheKey(streamName, host)
+    const k = ConnectionPool.getCacheKey(streamName, host, client.index)
     const currentlyCached = m.get(k) || []
     currentlyCached.push(client)
     m.set(k, currentlyCached)
@@ -36,7 +36,7 @@ export class ConnectionPool {
     const { leader, streamName, hostname: host } = connection
     if (streamName === undefined) return
     const m = leader ? ConnectionPool.publisherConnectionProxies : ConnectionPool.consumerConnectionProxies
-    const k = ConnectionPool.getCacheKey(streamName, host)
+    const k = ConnectionPool.getCacheKey(streamName, host, connection.index)
     const mappedClientList = m.get(k)
     if (mappedClientList) {
       const filtered = mappedClientList.filter((c) => c !== connection)
@@ -44,7 +44,7 @@ export class ConnectionPool {
     }
   }
 
-  private static getCacheKey(streamName: string, host: string) {
-    return `${streamName}@${host}`
+  private static getCacheKey(streamName: string, host: string, index: number) {
+    return `${streamName}-${index}@${host}`
   }
 }


### PR DESCRIPTION
Hello,

A single connection can only support 255 publishers or consumers, given that the publisherId is an 8 bit integer.

https://github.com/rabbitmq/rabbitmq-server/blob/main/deps/rabbitmq_stream/docs/PROTOCOL.adoc#declarepublisher

Other libraries like Go and Java create a new connection when this limit is reached: https://groups.google.com/g/rabbitmq-users/c/MQ-Bub3q13c/m/9-3cKfpbAAAJ

The issue with the current implementation is that the cached connection is always used when creating publishers, and this means that on the 256th publisher, it will crash because the publisherId of 256 won't fit into the 8 bit slot.

In this PR, we check to see if a connection can first support an additional publisher. If not, we create a new connection.

This would be a first-stab implementation. Please let me know any shortcomings and would be happy to fix.