### PR TITLE
feat: block message handler execution if consumer is closed

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -16,43 +16,43 @@
         "typescript": "^4.9.5"
       },
       "engines": {
-        "node": "16.x.x"
+        "node": "20.x.x"
       }
     },
     " ..": {
       "extraneous": true
     },
     "..": {
-      "version": "0.3.1",
+      "version": "0.4.1",
       "license": "ISC",
       "dependencies": {
         "semver": "^7.5.4"
       },
       "devDependencies": {
-        "@tsconfig/node16": "^1.0.3",
+        "@tsconfig/node-lts": "^20.1.1",
         "@types/amqplib": "^0.10.1",
         "@types/chai": "^4.3.4",
         "@types/chai-as-promised": "^7.1.8",
         "@types/chai-spies": "^1.0.6",
         "@types/mocha": "^10.0.1",
-        "@types/node": "^16.18.11",
-        "@typescript-eslint/eslint-plugin": "^5.50.0",
-        "@typescript-eslint/parser": "^5.50.0",
+        "@types/node": "^20.11.5",
+        "@typescript-eslint/eslint-plugin": "^6.19.0",
+        "@typescript-eslint/parser": "^6.19.0",
         "amqplib": "^0.10.3",
         "chai": "^4.3.7",
         "chai-as-promised": "^7.1.1",
         "chai-spies": "^1.1.0",
-        "cspell": "^6.21.0",
+        "cspell": "^7.3.9",
         "eslint": "^8.33.0",
-        "eslint-config-prettier": "^8.6.0",
-        "eslint-plugin-deprecation": "^1.3.3",
+        "eslint-config-prettier": "^9.1.0",
+        "eslint-plugin-deprecation": "^2.0.0",
         "eslint-plugin-import": "^2.27.5",
         "eslint-plugin-no-only-tests": "^3.1.0",
-        "eslint-plugin-prettier": "^4.2.1",
+        "eslint-plugin-prettier": "^5.1.3",
         "got": "^11.8.5",
         "mocha": "^10.2.0",
         "ts-node": "^10.9.1",
-        "typescript": "^4.9.5",
+        "typescript": "^5.3.3",
         "winston": "^3.8.2"
       }
     },
@@ -245,31 +245,31 @@
     "rabbitmq-stream-js-client": {
       "version": "file:..",
       "requires": {
-        "@tsconfig/node16": "^1.0.3",
+        "@tsconfig/node-lts": "^20.1.1",
         "@types/amqplib": "^0.10.1",
         "@types/chai": "^4.3.4",
         "@types/chai-as-promised": "^7.1.8",
         "@types/chai-spies": "^1.0.6",
         "@types/mocha": "^10.0.1",
-        "@types/node": "^16.18.11",
-        "@typescript-eslint/eslint-plugin": "^5.50.0",
-        "@typescript-eslint/parser": "^5.50.0",
+        "@types/node": "^20.11.5",
+        "@typescript-eslint/eslint-plugin": "^6.19.0",
+        "@typescript-eslint/parser": "^6.19.0",
         "amqplib": "^0.10.3",
         "chai": "^4.3.7",
         "chai-as-promised": "^7.1.1",
         "chai-spies": "^1.1.0",
-        "cspell": "^6.21.0",
+        "cspell": "^7.3.9",
         "eslint": "^8.33.0",
-        "eslint-config-prettier": "^8.6.0",
-        "eslint-plugin-deprecation": "^1.3.3",
+        "eslint-config-prettier": "^9.1.0",
+        "eslint-plugin-deprecation": "^2.0.0",
         "eslint-plugin-import": "^2.27.5",
         "eslint-plugin-no-only-tests": "^3.1.0",
-        "eslint-plugin-prettier": "^4.2.1",
+        "eslint-plugin-prettier": "^5.1.3",
         "got": "^11.8.5",
         "mocha": "^10.2.0",
         "semver": "^7.5.4",
         "ts-node": "^10.9.1",
-        "typescript": "^4.9.5",
+        "typescript": "^5.3.3",
         "winston": "^3.8.2"
       }
     },

--- a/example/src/offset_tracking_receive.js
+++ b/example/src/offset_tracking_receive.js
@@ -1,0 +1,59 @@
+const rabbit = require("rabbitmq-stream-js-client")
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+
+async function main() {
+  console.log("Connecting...")
+  const client = await rabbit.connect({
+    hostname: "localhost",
+    port: 5552,
+    username: "rabbit",
+    password: "rabbit",
+    vhost: "/",
+  })
+
+  console.log("Making sure the stream exists...")
+  const streamName = "stream-offset-tracking-javascript"
+  await client.createStream({ stream: streamName, arguments: {} })
+
+  const consumerRef = "offset-tracking-tutorial"
+  let firstOffset = undefined
+  let offsetSpecification = rabbit.Offset.first()
+  try {
+    const offset = await client.queryOffset({ reference: consumerRef, stream: streamName })
+    offsetSpecification = rabbit.Offset.offset(offset + 1n)
+  } catch (e) {}
+
+  let lastOffset = offsetSpecification.value
+  let messageCount = 0
+  const consumer = await client.declareConsumer(
+    { stream: streamName, offset: offsetSpecification, consumerRef },
+    async (message) => {
+      messageCount++
+      if (!firstOffset && messageCount === 1) {
+        firstOffset = message.offset
+        console.log("First message received")
+      }
+      if (messageCount % 10 === 0) {
+        await consumer.storeOffset(message.offset)
+      }
+      if (message.content.toString() === "marker") {
+        console.log("Marker found")
+        lastOffset = message.offset
+        await consumer.storeOffset(message.offset)
+        await consumer.close()
+      }
+    }
+  )
+
+  console.log(`Start consuming...`)
+  await sleep(2000)
+  console.log(`Done consuming, first offset was ${firstOffset}, last offset was ${lastOffset}`)
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((res) => {
+    console.log("Error while receiving message!", res)
+    process.exit(-1)
+  })

--- a/example/src/offset_tracking_send.js
+++ b/example/src/offset_tracking_send.js
@@ -1,0 +1,36 @@
+const rabbit = require("rabbitmq-stream-js-client")
+
+async function main() {
+  console.log("Connecting...")
+  const client = await rabbit.connect({
+    vhost: "/",
+    port: 5552,
+    hostname: "localhost",
+    username: "rabbit",
+    password: "rabbit",
+  })
+
+  console.log("Making sure the stream exists...")
+  const streamName = "stream-offset-tracking-javascript"
+  await client.createStream({ stream: streamName, arguments: {} })
+
+  console.log("Creating the publisher...")
+  const publisher = await client.declarePublisher({ stream: streamName })
+
+  const messageCount = 100
+  console.log(`Publishing ${messageCount} messages`)
+  for (let i = 0; i < messageCount; i++) {
+    const body = i === messageCount - 1 ? "marker" : `hello ${i}`
+    await publisher.send(Buffer.from(body))
+  }
+
+  console.log("Closing the connection...")
+  await client.close()
+}
+
+main()
+  .then(() => console.log("done!"))
+  .catch((res) => {
+    console.log("Error in publishing message!", res)
+    process.exit(-1)
+  })


### PR DESCRIPTION
When the consumer is closed we should stop handling the incoming messages in the stream. 
This beahviour has been seen on the offset tracking example of rabbitmq nodejs stream tutorials [here](https://github.com/rabbitmq/rabbitmq-tutorials/pull/445), with two sends in sequence, the consumer would read the queue until the end, instead of closing at the first marker found.