### PR TITLE
217 fix super stream consumer property

### DIFF
--- a/src/super_stream_consumer.ts
+++ b/src/super_stream_consumer.ts
@@ -5,6 +5,7 @@ import { Offset } from "./requests/subscribe_request"
 export class SuperStreamConsumer {
   private consumers: Map<string, Consumer> = new Map<string, Consumer>()
   public consumerRef: string
+  readonly superStream: string
   private locator: Client
   private partitions: string[]
   private offset: Offset
@@ -12,12 +13,14 @@ export class SuperStreamConsumer {
   private constructor(
     readonly handle: ConsumerFunc,
     params: {
+      superStream: string
       locator: Client
       partitions: string[]
       consumerRef: string
       offset: Offset
     }
   ) {
+    this.superStream = params.superStream
     this.consumerRef = params.consumerRef
     this.locator = params.locator
     this.partitions = params.partitions
@@ -29,7 +32,8 @@ export class SuperStreamConsumer {
       this.partitions.map(async (p) => {
         const partitionConsumer = await this.locator.declareConsumer(
           { stream: p, consumerRef: this.consumerRef, offset: this.offset, singleActive: true },
-          this.handle
+          this.handle,
+          this
         )
         this.consumers.set(p, partitionConsumer)
         return
@@ -40,6 +44,7 @@ export class SuperStreamConsumer {
   static async create(
     handle: ConsumerFunc,
     params: {
+      superStream: string
       locator: Client
       partitions: string[]
       consumerRef: string

--- a/test/e2e/superstream_consumer.test.ts
+++ b/test/e2e/superstream_consumer.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai"
 import { Client, Offset } from "../../src"
-import { Message } from "../../src/publisher"
+import { Message, MessageOptions } from "../../src/publisher"
 import { range } from "../../src/util"
 import { createClient, createStreamName } from "../support/fake_data"
 import { Rabbit } from "../support/rabbit"
@@ -17,8 +17,6 @@ describe("super stream consumer", () => {
   beforeEach(async () => {
     client = await createClient(username, password)
     superStreamName = createStreamName()
-    noOfPartitions = await rabbit.createSuperStream(superStreamName)
-    sender = await messageSender(client, superStreamName)
   })
 
   afterEach(async () => {
@@ -30,118 +28,161 @@ describe("super stream consumer", () => {
     } catch (e) {}
   })
 
-  it("querying partitions - return the same number of partitions", async () => {
-    const partitions = await client.queryPartitions({ superStream: superStreamName })
-
-    expect(partitions.length).to.be.equal(noOfPartitions)
-  })
-
-  it("querying partitions - return the name of the streams making up the superstream", async () => {
-    const partitions = await client.queryPartitions({ superStream: superStreamName })
-
-    expect(range(noOfPartitions).map((i) => `${superStreamName}-${i}`)).to.deep.eq(partitions)
-  })
-
-  it("declaring a super stream consumer on an existing super stream - no error is thrown", async () => {
-    await client.declareSuperStreamConsumer({ superStream: superStreamName }, (_message: Message) => {
-      return
-    })
-  })
-
-  it("declaring a super stream consumer on an existing super stream - read a message", async () => {
-    await sender(1)
-    const messages: Message[] = []
-
-    await client.declareSuperStreamConsumer({ superStream: superStreamName }, (message: Message) => {
-      messages.push(message)
+  describe("random partitioning", () => {
+    beforeEach(async () => {
+      noOfPartitions = await rabbit.createSuperStream(superStreamName)
+      sender = await messageSender(client, superStreamName)
     })
 
-    await eventually(() => {
-      expect(messages).to.have.length(1)
-      const [message] = messages
-      expect(message.content.toString()).to.be.eq(`${testMessageContent}-0`)
-    })
-  })
+    it("querying partitions - return the same number of partitions", async () => {
+      const partitions = await client.queryPartitions({ superStream: superStreamName })
 
-  it("for a consumer the number of connections should be equals to the partitions' number", async () => {
-    await client.declareSuperStreamConsumer({ superStream: superStreamName }, (_) => {
-      return
+      expect(partitions.length).to.be.equal(noOfPartitions)
     })
 
-    await eventually(() => {
-      expect(client.consumerCounts()).to.be.eql(noOfPartitions)
-    })
-  })
+    it("querying partitions - return the name of the streams making up the superstream", async () => {
+      const partitions = await client.queryPartitions({ superStream: superStreamName })
 
-  it("reading multiple messages - each message should be read only once", async () => {
-    const noOfMessages = 20
-    await sender(noOfMessages)
-    const messages: Message[] = []
-
-    await client.declareSuperStreamConsumer({ superStream: superStreamName }, (message: Message) => {
-      messages.push(message)
+      expect(range(noOfPartitions).map((i) => `${superStreamName}-${i}`)).to.deep.eq(partitions)
     })
 
-    await eventually(() => {
-      expect(messages).to.have.length(noOfMessages)
+    it("declaring a super stream consumer on an existing super stream - no error is thrown", async () => {
+      await client.declareSuperStreamConsumer({ superStream: superStreamName }, (_message: Message) => {
+        return
+      })
     })
-  })
 
-  it("multiple composite consumers with same consumerRef - each message should be read only once", async () => {
-    const noOfMessages = 20
-    const messages: Message[] = []
+    it("declaring a super stream consumer on an existing super stream - read a message", async () => {
+      await sender(1)
+      const messages: Message[] = []
 
-    await client.declareSuperStreamConsumer(
-      { superStream: superStreamName, consumerRef: "counting-messages" },
-      (message: Message) => messages.push(message)
-    )
-    await client.declareSuperStreamConsumer(
-      { superStream: superStreamName, consumerRef: "counting-messages" },
-      (message: Message) => messages.push(message)
-    )
-
-    await sender(noOfMessages)
-
-    await eventually(() => {
-      expect(messages).to.have.length(noOfMessages)
-    })
-  })
-
-  it("reading multiple messages - get messages only at a specific consuming point timestamp", async () => {
-    const noOfMessages = 20
-    await sender(5)
-    const sleepingTime = 5000
-    await sleep(sleepingTime)
-    await sender(noOfMessages)
-    const messages: Message[] = []
-
-    await client.declareSuperStreamConsumer(
-      {
-        superStream: superStreamName,
-        offset: Offset.timestamp(new Date(Date.now() - (sleepingTime - 1000))),
-      },
-      (message: Message) => {
+      await client.declareSuperStreamConsumer({ superStream: superStreamName }, (message: Message) => {
         messages.push(message)
+      })
+
+      await eventually(() => {
+        expect(messages).to.have.length(1)
+        const [message] = messages
+        expect(message.content.toString()).to.be.eq(`${testMessageContent}-0`)
+      })
+    })
+
+    it("for a consumer the number of connections should be equals to the partitions' number", async () => {
+      await client.declareSuperStreamConsumer({ superStream: superStreamName }, (_) => {
+        return
+      })
+
+      await eventually(() => {
+        expect(client.consumerCounts()).to.be.eql(noOfPartitions)
+      })
+    })
+
+    it("reading multiple messages - each message should be read only once", async () => {
+      const noOfMessages = 20
+      await sender(noOfMessages)
+      const messages: Message[] = []
+
+      await client.declareSuperStreamConsumer({ superStream: superStreamName }, (message: Message) => {
+        messages.push(message)
+      })
+
+      await eventually(() => {
+        expect(messages).to.have.length(noOfMessages)
+      })
+    })
+
+    it("multiple composite consumers with same consumerRef - each message should be read only once", async () => {
+      const noOfMessages = 20
+      const messages: Message[] = []
+
+      await client.declareSuperStreamConsumer(
+        { superStream: superStreamName, consumerRef: "counting-messages" },
+        (message: Message) => messages.push(message)
+      )
+      await client.declareSuperStreamConsumer(
+        { superStream: superStreamName, consumerRef: "counting-messages" },
+        (message: Message) => messages.push(message)
+      )
+
+      await sender(noOfMessages)
+
+      await eventually(() => {
+        expect(messages).to.have.length(noOfMessages)
+      })
+    })
+
+    it("reading multiple messages - get messages only at a specific consuming point timestamp", async () => {
+      const noOfMessages = 20
+      await sender(5)
+      const sleepingTime = 5000
+      await sleep(sleepingTime)
+      await sender(noOfMessages)
+      const messages: Message[] = []
+
+      await client.declareSuperStreamConsumer(
+        {
+          superStream: superStreamName,
+          offset: Offset.timestamp(new Date(Date.now() - (sleepingTime - 1000))),
+        },
+        (message: Message) => {
+          messages.push(message)
+        }
+      )
+
+      await eventually(() => {
+        expect(messages).to.have.length(noOfMessages)
+      })
+    }).timeout(10000)
+
+    it("closing the locator closes all connections", async () => {
+      await client.declareSuperStreamConsumer({ superStream: superStreamName }, (_) => {
+        return
+      })
+
+      await client.close()
+
+      await eventually(async () => {
+        const connections = await rabbit.getConnections()
+        expect(connections).to.have.length(0)
+      }, 5000)
+    }).timeout(5000)
+  })
+
+  describe("deterministic partitioning", () => {
+    beforeEach(async () => {
+      noOfPartitions = await rabbit.createSuperStream(superStreamName, 2)
+      sender = await roundRobinSender(client, superStreamName, 2)
+    })
+
+    it("multiple composite consumers with same consumerRef and deterministic partition key - each consumer should read only messages for its partition", async () => {
+      const noOfMessagesPerPartition = 10
+      const messages: Message[][] = [[], []]
+
+      const allPartitionKeysAreTheSame = (messages) => {
+        const partitionKeys = messages.map(m => m.applicationProperties['partition-key'])
+        return partitionKeys.every(k => k === partitionKeys[0])
       }
-    )
 
-    await eventually(() => {
-      expect(messages).to.have.length(noOfMessages)
+      await client.declareSuperStreamConsumer(
+        { superStream: superStreamName, consumerRef: "message-partitioning" },
+        (message: Message) => messages[0].push(message)
+      )
+      await client.declareSuperStreamConsumer(
+        { superStream: superStreamName, consumerRef: "message-partitioning" },
+        (message: Message) => messages[1].push(message)
+      )
+
+      await sender(noOfMessagesPerPartition)
+
+      await eventually(() => {
+        expect(messages[0]).to.have.length(noOfMessagesPerPartition)
+        expect(allPartitionKeysAreTheSame(messages[0]))
+
+        expect(messages[1]).to.have.length(noOfMessagesPerPartition)
+        expect(allPartitionKeysAreTheSame(messages[1]))
+      })
     })
-  }).timeout(10000)
-
-  it("closing the locator closes all connections", async () => {
-    await client.declareSuperStreamConsumer({ superStream: superStreamName }, (_) => {
-      return
-    })
-
-    await client.close()
-
-    await eventually(async () => {
-      const connections = await rabbit.getConnections()
-      expect(connections).to.have.length(0)
-    }, 5000)
-  }).timeout(5000)
+  })
 })
 
 const testMessageContent = "test message"
@@ -152,6 +193,24 @@ const messageSender = async (client: Client, superStreamName: string) => {
   const sendMessages = async (noOfMessages: number) => {
     for (let i = 0; i < noOfMessages; i++) {
       await publisher.send(Buffer.from(`${testMessageContent}-${i}`), {})
+    }
+  }
+
+  return sendMessages
+}
+
+const roundRobinSender = async (client: Client, superStreamName: string, partitions: number) => {
+  const routingKeyExtractor = (_content: string, msgOptions: MessageOptions) =>
+    msgOptions.applicationProperties?.["partition-key"]?.toString()
+  const publisher = await client.declareSuperStreamPublisher({ superStream: superStreamName }, routingKeyExtractor)
+
+  const sendMessages = async (noOfMessagesPerPartition: number) => {
+    for (let i = 0; i < noOfMessagesPerPartition; i++) {
+      for (let p = 0; p < partitions; p++) {
+        await publisher.send(Buffer.from(`${testMessageContent}-${i * partitions + p}`), {
+          applicationProperties: { "partition-key": `${p}` },
+        })
+      }
     }
   }
 

--- a/test/e2e/superstream_consumer.test.ts
+++ b/test/e2e/superstream_consumer.test.ts
@@ -158,9 +158,9 @@ describe("super stream consumer", () => {
       const noOfMessagesPerPartition = 10
       const messages: Message[][] = [[], []]
 
-      const allPartitionKeysAreTheSame = (messages) => {
-        const partitionKeys = messages.map(m => m.applicationProperties['partition-key'])
-        return partitionKeys.every(k => k === partitionKeys[0])
+      const allPartitionKeysAreTheSame = (messagesToCheck: Message[]) => {
+        const partitionKeys = messagesToCheck.map((m) => m.applicationProperties?.["partition-key"])
+        return partitionKeys.every((k) => k === partitionKeys[0])
       }
 
       await client.declareSuperStreamConsumer(


### PR DESCRIPTION
Fixes #217 

---

The active part of the change is adding the property to the consumer:
https://github.com/coders51/rabbitmq-stream-js-client/pull/218/files#diff-25d66d74617fe2e23d7946bd6e3ba95640ab1b9bc8947445d604fc271c7c1f12R490-R492
```ts
    if (superStream) {
      properties["super-stream"] = superStream
    }
```

The rest is plumbing to get the super stream name passed down to the right place.

I have added a test which fails on `main` and passes on this branch. I have included it inside the existing super stream consumer end-to-end test.

I'd be happy to work through any comments or suggested restructures in order to get this in shape to be merged.

Thanks