### PR TITLE
wip: single active consumer offset tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,25 @@ const consumer = await client.declareConsumer(consumerOptions, (message: Message
 // ...
 ```
 
+Optionally a single active consumer can have a callback which returns an offset that will be used once the consumer becomes active
+
+```typescript
+const consumerOptions = {
+  stream: "stream-name",
+  offset: Offset.next(),
+  singleActive: true,
+  consumerRef: "my-consumer-ref",
+  consumerUpdateListener: async (consumerReference, streamName) => {
+    const offset = await client.queryOffset({ reference: consumerReference, stream: streamName })
+    return rabbit.Offset.offset(offset)
+  },
+}
+
+// ...
+```
+
+Check `example/single_active_consumer_update_example.js` for a basic usage example.
+
 ### Custom Policy
 
 By default the client uses the `creditsOnChunkCompleted(1, 1)` policy. This policy grants that messages will be processed in order, as a new chunk will only be requested once the current chunk has been processed. It is possible to override this policy by passing `creditPolicy` to the consumer options. Be aware that modifying this policy can lead to out-of-order message processing.

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -23,7 +23,7 @@
       "extraneous": true
     },
     "..": {
-      "version": "0.5.1",
+      "version": "0.6.0",
       "license": "ISC",
       "dependencies": {
         "semver": "^7.5.4"
@@ -38,7 +38,7 @@
         "@types/node": "^20.11.5",
         "@typescript-eslint/eslint-plugin": "^6.19.0",
         "@typescript-eslint/parser": "^6.19.0",
-        "amqplib": "^0.10.3",
+        "amqplib": "^0.10.5",
         "chai": "^4.3.7",
         "chai-as-promised": "^7.1.1",
         "chai-spies": "^1.1.0",
@@ -254,7 +254,7 @@
         "@types/node": "^20.11.5",
         "@typescript-eslint/eslint-plugin": "^6.19.0",
         "@typescript-eslint/parser": "^6.19.0",
-        "amqplib": "^0.10.3",
+        "amqplib": "^0.10.5",
         "chai": "^4.3.7",
         "chai-as-promised": "^7.1.1",
         "chai-spies": "^1.1.0",

--- a/example/src/single_active_consumer_update_example.js
+++ b/example/src/single_active_consumer_update_example.js
@@ -1,0 +1,90 @@
+const rabbit = require("rabbitmq-stream-js-client")
+const crypto = require("crypto")
+
+const wait = (ms) => new Promise((r) => setTimeout(r, ms))
+
+async function main() {
+  const messagesFromFirstConsumer = []
+  const messagesFromSecondConsumer = []
+
+  console.log("Connecting...")
+  const client = await rabbit.connect({
+    vhost: "/",
+    port: 5552,
+    hostname: "localhost",
+    username: "rabbit",
+    password: "rabbit",
+  })
+
+  console.log("Making sure the stream exists...")
+  const streamName = "stream-single-active-consumer-update-javascript"
+  await client.createStream({ stream: streamName, arguments: {} })
+  const consumerRef = `my-consumer-${crypto.randomUUID()}`
+
+  console.log("Creating the publisher and sending 100 messages...")
+  const publisher = await client.declarePublisher({ stream: streamName })
+  for (let i = 1; i <= 100; i++) {
+    await publisher.send(Buffer.from(`${i}`))
+  }
+
+  console.log("Creating the first consumer, when 50 messages are consumed it saves the offset on the server...")
+  const consumer1 = await client.declareConsumer(
+    {
+      stream: streamName,
+      offset: rabbit.Offset.first(),
+      singleActive: true,
+      consumerRef: consumerRef,
+      consumerUpdateListener: async (consumerReference, streamName) => {
+        const offset = await client.queryOffset({ reference: consumerReference, stream: streamName })
+        return rabbit.Offset.offset(offset)
+      },
+    },
+    async (message) => {
+      messagesFromFirstConsumer.push(`Message ${message.content.toString("utf-8")} from ${consumerRef}`)
+      if (messagesFromFirstConsumer.length === 50) {
+        await consumer1.storeOffset(message.offset)
+      }
+    }
+  )
+
+  await wait(500)
+
+  console.log("Creating the second consumer, when it becomes active it resumes from the stored offset on the server...")
+  await client.declareConsumer(
+    {
+      stream: streamName,
+      offset: rabbit.Offset.first(),
+      singleActive: true,
+      consumerRef: consumerRef,
+      // This callback is executed when the consumer becomes active
+      consumerUpdateListener: async (consumerReference, streamName) => {
+        const offset = await client.queryOffset({ reference: consumerReference, stream: streamName })
+        return rabbit.Offset.offset(offset)
+      },
+    },
+    (message) => {
+      messagesFromSecondConsumer.push(`Message ${message.content.toString("utf-8")} from ${consumerRef}`)
+    }
+  )
+
+  console.log("Closing the first consumer to trigger the activation of the second one...")
+  await client.closeConsumer(consumer1.extendedId)
+
+  await wait(500)
+
+  console.log(`Messages consumed by the first consumer: ${messagesFromFirstConsumer.length}`)
+  console.log(
+    `Messages consumed by the second consumer: ${messagesFromSecondConsumer.length}`,
+    messagesFromSecondConsumer
+  )
+}
+
+main()
+  .then(() => {
+    console.log("done!")
+    process.exit(0)
+  })
+  .catch((res) => {
+    console.log("Error in publishing message!", res)
+    process.exit(-1)
+  })

--- a/example/src/single_active_consumer_update_example.js
+++ b/example/src/single_active_consumer_update_example.js
@@ -34,10 +34,6 @@ async function main() {
       offset: rabbit.Offset.first(),
       singleActive: true,
       consumerRef: consumerRef,
-      consumerUpdateListener: async (consumerReference, streamName) => {
-        const offset = await client.queryOffset({ reference: consumerReference, stream: streamName })
-        return rabbit.Offset.offset(offset)
-      },
     },
     async (message) => {
       messagesFromFirstConsumer.push(`Message ${message.content.toString("utf-8")} from ${consumerRef}`)
@@ -73,10 +69,7 @@ async function main() {
   await wait(500)
 
   console.log(`Messages consumed by the first consumer: ${messagesFromFirstConsumer.length}`)
-  console.log(
-    `Messages consumed by the second consumer: ${messagesFromSecondConsumer.length}`,
-    messagesFromSecondConsumer
-  )
+  console.log(`Messages consumed by the second consumer: ${messagesFromSecondConsumer.length}`)
 }
 
 main()

--- a/example/src/single_active_consumer_update_example.js
+++ b/example/src/single_active_consumer_update_example.js
@@ -17,7 +17,7 @@ async function main() {
   })
 
   console.log("Making sure the stream exists...")
-  const streamName = "stream-single-active-consumer-update-javascript"
+  const streamName = "active-consumer-switch-on-single-active-consumer"
   await client.createStream({ stream: streamName, arguments: {} })
   const consumerRef = `my-consumer-${crypto.randomUUID()}`
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -606,6 +606,9 @@ export class Client {
         const offset = await consumer.consumerUpdateListener(consumer.consumerRef, consumer.streamName)
         return offset
       } catch (error) {
+        this.logger.error(
+          `Error in consumerUpdateListener for consumerRef ${consumer.consumerRef}: ${(error as Error).message}`
+        )
         return consumer.offset
       }
     }

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -548,7 +548,6 @@ export class Connection {
   }
 
   public storeOffset(params: StoreOffsetParams): Promise<void> {
-    console.log("AHAH")
     return this.send(new StoreOffsetRequest(params))
   }
 

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -548,6 +548,7 @@ export class Connection {
   }
 
   public storeOffset(params: StoreOffsetParams): Promise<void> {
+    console.log("AHAH")
     return this.send(new StoreOffsetRequest(params))
   }
 

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -41,6 +41,8 @@ export interface Consumer {
    */
   getConnectionInfo(): ConnectionInfo
 
+  updateConsumerOffset(offset: Offset): void
+
   consumerId: number
   consumerRef?: string
   readonly extendedId: string
@@ -136,6 +138,11 @@ export class StreamConsumer implements Consumer {
 
   public get isSingleActive() {
     return this.singleActive
+  }
+
+  public updateConsumerOffset(offset: Offset) {
+    this.offset = offset.clone()
+    this.clientLocalOffset = offset.clone()
   }
 
   private maybeUpdateLocalOffset(message: Message) {

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -41,6 +41,11 @@ export interface Consumer {
    */
   getConnectionInfo(): ConnectionInfo
 
+  /**
+   * Updates the offset of the consumer instance
+   *
+   * @param {Offset} offset - The new offset to set
+   */
   updateConsumerOffset(offset: Offset): void
 
   consumerId: number

--- a/test/e2e/declare_consumer.test.ts
+++ b/test/e2e/declare_consumer.test.ts
@@ -217,59 +217,56 @@ describe("declare consumer", () => {
     await eventually(() => expect(messages).eql([Buffer.from("hello"), Buffer.from("hello")]))
   }).timeout(10000)
 
-  it.only(
-    "declaring two single active consumer on an existing stream - after closing one consumer the active one can resume the consuming from the last saved offset on the server",
-    async () => {
-      const messagesFromFirstConsumer: string[] = []
-      const messagesFromSecondConsumer: string[] = []
-      const consumerRef = createConsumerRef()
-      for (let i = 1; i <= 100; i++) {
-        await publisher.send(Buffer.from(`${i}`))
-      }
-
-      const consumer1 = await client.declareConsumer(
-        {
-          stream: streamName,
-          offset: Offset.first(),
-          singleActive: true,
-          consumerRef: consumerRef,
-          consumerUpdateListener: async (cr: string, sn: string) => {
-            const offset = await client.queryOffset({ reference: cr, stream: sn })
-            return Offset.offset(offset)
-          },
-        },
-        async (message: Message) => {
-          messagesFromFirstConsumer.push(`Message ${message.content.toString("utf-8")} from ${consumerRef}`)
-          if (messagesFromFirstConsumer.length === 50) await consumer1.storeOffset(message.offset!)
-        }
-      )
-      await wait(500)
-      await client.declareConsumer(
-        {
-          stream: streamName,
-          offset: Offset.first(),
-          singleActive: true,
-          consumerRef: consumerRef,
-          consumerUpdateListener: async (cr: string, sn: string) => {
-            const offset = await client.queryOffset({ reference: cr, stream: sn })
-            return Offset.offset(offset)
-          },
-        },
-        (message: Message) => {
-          console.log(`Message ${message.content.toString("utf-8")} from ${consumerRef}`)
-          messagesFromSecondConsumer.push(`Message ${message.content.toString("utf-8")} from ${consumerRef}`)
-        }
-      )
-      await client.closeConsumer(consumer1.extendedId)
-      await wait(500)
-
-      await eventually(
-        () =>
-          expect(messagesFromSecondConsumer.find((m) => m === `Message 50 from ${consumerRef}`)).to.not.be.undefined,
-        8000
-      )
+  it("declaring two single active consumer on an existing stream - after closing one consumer the active one can resume the consuming from the last saved offset on the server", async () => {
+    const messagesFromFirstConsumer: string[] = []
+    const messagesFromSecondConsumer: string[] = []
+    const consumerRef = createConsumerRef()
+    for (let i = 1; i <= 100; i++) {
+      await publisher.send(Buffer.from(`${i}`))
     }
-  ).timeout(20000)
+
+    const consumer1 = await client.declareConsumer(
+      {
+        stream: streamName,
+        offset: Offset.first(),
+        singleActive: true,
+        consumerRef: consumerRef,
+        consumerUpdateListener: async (cr: string, sn: string) => {
+          const offset = await client.queryOffset({ reference: cr, stream: sn })
+          return Offset.offset(offset)
+        },
+      },
+      async (message: Message) => {
+        messagesFromFirstConsumer.push(`Message ${message.content.toString("utf-8")} from ${consumerRef}`)
+        if (messagesFromFirstConsumer.length === 50) {
+          await consumer1.storeOffset(message.offset!)
+        }
+      }
+    )
+    await wait(500)
+    await client.declareConsumer(
+      {
+        stream: streamName,
+        offset: Offset.first(),
+        singleActive: true,
+        consumerRef: consumerRef,
+        consumerUpdateListener: async (cr: string, sn: string) => {
+          const offset = await client.queryOffset({ reference: cr, stream: sn })
+          return Offset.offset(offset)
+        },
+      },
+      (message: Message) => {
+        messagesFromSecondConsumer.push(`Message ${message.content.toString("utf-8")} from ${consumerRef}`)
+      }
+    )
+    await client.closeConsumer(consumer1.extendedId)
+    await wait(500)
+
+    await eventually(() => {
+      expect(messagesFromSecondConsumer.find((m) => m === `Message 50 from ${consumerRef}`)).to.not.be.undefined
+      expect(messagesFromSecondConsumer.find((m) => m === `Message 49 from ${consumerRef}`)).to.be.undefined
+    }, 8000)
+  }).timeout(20000)
 
   it("declaring a single active consumer without reference on an existing stream - should throw an error", async () => {
     const messages: Buffer[] = []

--- a/test/e2e/declare_consumer.test.ts
+++ b/test/e2e/declare_consumer.test.ts
@@ -30,6 +30,7 @@ import {
   getTestNodesFromEnv,
   password,
   username,
+  wait,
   waitSleeping,
 } from "../support/util"
 import { Connection, Channel } from "amqplib"
@@ -215,6 +216,60 @@ describe("declare consumer", () => {
 
     await eventually(() => expect(messages).eql([Buffer.from("hello"), Buffer.from("hello")]))
   }).timeout(10000)
+
+  it.only(
+    "declaring two single active consumer on an existing stream - after closing one consumer the active one can resume the consuming from the last saved offset on the server",
+    async () => {
+      const messagesFromFirstConsumer: string[] = []
+      const messagesFromSecondConsumer: string[] = []
+      const consumerRef = createConsumerRef()
+      for (let i = 1; i <= 100; i++) {
+        await publisher.send(Buffer.from(`${i}`))
+      }
+
+      const consumer1 = await client.declareConsumer(
+        {
+          stream: streamName,
+          offset: Offset.first(),
+          singleActive: true,
+          consumerRef: consumerRef,
+          consumerUpdateListener: async (cr: string, sn: string) => {
+            const offset = await client.queryOffset({ reference: cr, stream: sn })
+            return Offset.offset(offset)
+          },
+        },
+        async (message: Message) => {
+          messagesFromFirstConsumer.push(`Message ${message.content.toString("utf-8")} from ${consumerRef}`)
+          if (messagesFromFirstConsumer.length === 50) await consumer1.storeOffset(message.offset!)
+        }
+      )
+      await wait(500)
+      await client.declareConsumer(
+        {
+          stream: streamName,
+          offset: Offset.first(),
+          singleActive: true,
+          consumerRef: consumerRef,
+          consumerUpdateListener: async (cr: string, sn: string) => {
+            const offset = await client.queryOffset({ reference: cr, stream: sn })
+            return Offset.offset(offset)
+          },
+        },
+        (message: Message) => {
+          console.log(`Message ${message.content.toString("utf-8")} from ${consumerRef}`)
+          messagesFromSecondConsumer.push(`Message ${message.content.toString("utf-8")} from ${consumerRef}`)
+        }
+      )
+      await client.closeConsumer(consumer1.extendedId)
+      await wait(500)
+
+      await eventually(
+        () =>
+          expect(messagesFromSecondConsumer.find((m) => m === `Message 50 from ${consumerRef}`)).to.not.be.undefined,
+        8000
+      )
+    }
+  ).timeout(20000)
 
   it("declaring a single active consumer without reference on an existing stream - should throw an error", async () => {
     const messages: Buffer[] = []


### PR DESCRIPTION
This pr adds a consumer update listener in the consumer. In this way, the end user can customize the behaviour of a single active consumer when it becomes active. An example is also added to show how a single active consumer can resume the consuming of messages from a specific offset, upon activation.