### PR TITLE
Add option to simply enable TLS instead of providing certain config parameters, and also remove hardcoded `rejectUnauthorized = false`

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -750,17 +750,23 @@ export type ClientListenersParams = {
   connection_closed?: ConnectionClosedListener
 }
 
-export interface SSLConnectionParams {
-  key: string
-  cert: string
-  ca?: string
+export type SSLConnectionParams = {
+  enabled: true
+  options?: {
+    key: string
+    cert: string
+    ca?: string
+    rejectUnauthorized?: boolean
+  }
+} | {
+  enabled: false
 }
 
 export type AddressResolverParams =
   | {
-      enabled: true
-      endpoint?: { host: string; port: number }
-    }
+    enabled: true
+    endpoint?: { host: string; port: number }
+  }
   | { enabled: false }
 
 export interface ClientParams {

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -133,11 +133,9 @@ export class Connection {
   }
 
   private createSocket() {
-    const socket = this.params.ssl
-      ? tls.connect(this.params.port, this.params.hostname, {
-          ...this.params.ssl,
-          rejectUnauthorized: false,
-        })
+    const sslEnabled = this.params.ssl !== undefined && this.params.ssl.enabled === true
+    const socket = sslEnabled
+      ? tls.connect(this.params.port, this.params.hostname, this.params.ssl)
       : new Socket().connect(this.params.port, this.params.hostname)
     if (this.params.socketTimeout) socket.setTimeout(this.params.socketTimeout)
     return socket
@@ -416,8 +414,7 @@ export class Connection {
       const bufferSizeParams = this.getBufferSizeParams()
       const body = cmd.toBuffer(bufferSizeParams)
       this.logger.debug(
-        `Write cmd key: ${cmd.key.toString(16)} - no correlationId - data: ${inspect(body.toJSON())} length: ${
-          body.byteLength
+        `Write cmd key: ${cmd.key.toString(16)} - no correlationId - data: ${inspect(body.toJSON())} length: ${body.byteLength
         }`
       )
       this.socket.write(body, (err) => {

--- a/test/e2e/connect.test.ts
+++ b/test/e2e/connect.test.ts
@@ -14,9 +14,12 @@ async function createTlsClient(): Promise<Client> {
     port: 5551,
     mechanism: "EXTERNAL",
     ssl: {
-      ca: await readFile("./tls-gen/basic/result/ca_certificate.pem", "utf8"),
-      cert: await readFile(`./tls-gen/basic/result/client_${firstNode.host}_certificate.pem`, "utf8"),
-      key: await readFile(`./tls-gen/basic/result/client_${firstNode.host}_key.pem`, "utf8"),
+      enabled: true,
+      options: {
+        ca: await readFile("./tls-gen/basic/result/ca_certificate.pem", "utf8"),
+        cert: await readFile(`./tls-gen/basic/result/client_${firstNode.host}_certificate.pem`, "utf8"),
+        key: await readFile(`./tls-gen/basic/result/client_${firstNode.host}_key.pem`, "utf8"),
+      },
     },
     username: "",
     password: "",

--- a/test/e2e/connect.test.ts
+++ b/test/e2e/connect.test.ts
@@ -19,6 +19,7 @@ async function createTlsClient(): Promise<Client> {
         ca: await readFile("./tls-gen/basic/result/ca_certificate.pem", "utf8"),
         cert: await readFile(`./tls-gen/basic/result/client_${firstNode.host}_certificate.pem`, "utf8"),
         key: await readFile(`./tls-gen/basic/result/client_${firstNode.host}_key.pem`, "utf8"),
+        rejectUnauthorized: true,
       },
     },
     username: "",


### PR DESCRIPTION
Tests aren't working on my local before my changes and I haven't had a time to troubleshoot. Hopefully what exists in this PR can be a good jumping off point!