### PR TITLE
260 refactoring: manage connections inside pool

### DIFF
--- a/src/connection_pool.ts
+++ b/src/connection_pool.ts
@@ -15,8 +15,8 @@ export class ConnectionPool {
     connectionCreator: () => Promise<Connection>
   ) {
     const key = this.getCacheKey(streamName, vhost, host, entityType)
-    const proxies = this.connectionsMap.get(key) || []
-    const connection = proxies.at(-1)
+    const connections = this.connectionsMap.get(key) || []
+    const connection = connections.at(-1)
     const refCount = connection?.refCount
     const cachedConnection =
       refCount !== undefined && refCount < getMaxSharedConnectionInstances() ? connection : undefined

--- a/src/connection_pool.ts
+++ b/src/connection_pool.ts
@@ -25,7 +25,7 @@ export class ConnectionPool {
       return cachedConnection
     } else {
       const newConnection = await connectionCreator()
-      this.cacheConnection(this.connectionsMap, key, newConnection)
+      this.cacheConnection(key, newConnection)
       return newConnection
     }
   }
@@ -38,10 +38,10 @@ export class ConnectionPool {
     }
   }
 
-  private cacheConnection(map: Map<InstanceKey, Connection[]>, key: string, connection: Connection) {
-    const currentlyCached = map.get(key) || []
+  private cacheConnection(key: string, connection: Connection) {
+    const currentlyCached = this.connectionsMap.get(key) || []
     currentlyCached.push(connection)
-    map.set(key, currentlyCached)
+    this.connectionsMap.set(key, currentlyCached)
   }
 
   private removeCachedConnection(connection: Connection) {

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -97,12 +97,9 @@ export class StreamConsumer implements Consumer {
     this.singleActive = params.singleActive ?? false
   }
 
-  async close(manuallyClose: boolean): Promise<void> {
+  async close(): Promise<void> {
     this.closed = true
-    this.connection.decrRefCount()
-    if (this.pool.removeIfUnused(this.connection)) {
-      await this.connection.close({ closingCode: 0, closingReason: "", manuallyClose })
-    }
+    await this.pool.releaseConnection(this.connection)
   }
 
   public storeOffset(offsetValue: bigint): Promise<void> {

--- a/src/publisher.ts
+++ b/src/publisher.ts
@@ -281,10 +281,7 @@ export class StreamPublisher implements Publisher {
   public async close(manuallyClose: boolean): Promise<void> {
     if (!this.closed) {
       await this.flush()
-      this.connection.decrRefCount()
-      if (this.pool.removeIfUnused(this.connection)) {
-        await this.connection.close({ closingCode: 0, closingReason: "", manuallyClose })
-      }
+      await this.pool.releaseConnection(this.connection, manuallyClose)
     }
     this._closed = true
   }


### PR DESCRIPTION
So far we kept the `manuallyClose` param, but the `refCount` and connection caching are managed inside the `ConnectionPool`.