### PR TITLE
fix: reading bytes in log

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -404,7 +404,7 @@ export class Connection {
   }
 
   private received(data: Buffer) {
-    this.logger.debug(`Receiving ${data.length} (${data.readIntBE(0, data.length)}) bytes ... ${inspect(data)}`)
+    this.logger.debug(`Receiving ${data.length} bytes ... ${inspect(data)}`)
     this.decoder.add(data, (ct) => this.getCompression(ct))
   }
 


### PR DESCRIPTION
We remove the call to `readInt32BE` since the length of bytes we receive is variable