### PR TITLE
fix: add missing smalllong (0x55) and long (0x81) AMQP 1.0 format

### DIFF
--- a/src/amqp10/decoder.ts
+++ b/src/amqp10/decoder.ts
@@ -31,6 +31,8 @@ export const FormatCode = {
   Int: 0x71,
   SmallUint: 0x52,
   SmallInt: 0x54,
+  SmallLong: 0x55,
+  Long: 0x81,
   Timestamp: 0x83,
   Bool: 0x56,
   BoolTrue: 0x41,

--- a/src/response_decoder.ts
+++ b/src/response_decoder.ts
@@ -438,8 +438,12 @@ export function decodeFormatCode(dataResponse: DataReader, formatCode: number) {
       return dataResponse.readUInt32()
     case FormatCode.SmallInt:
       return dataResponse.readInt8()
+    case FormatCode.SmallLong:
+      return dataResponse.readInt8()
     case FormatCode.Int:
       return dataResponse.readInt32()
+    case FormatCode.Long:
+      return dataResponse.readInt64()
     case FormatCode.Bool:
     case FormatCode.BoolTrue:
     case FormatCode.BoolFalse:

--- a/test/e2e/declare_consumer.test.ts
+++ b/test/e2e/declare_consumer.test.ts
@@ -11,8 +11,10 @@ import {
   MessageHeader,
   MessageProperties,
 } from "../../src/publisher"
+import { Annotations } from "../../src/amqp10/messageAnnotations"
+import { FormatCode } from "../../src/amqp10/decoder"
 import { Offset } from "../../src/requests/subscribe_request"
-import { BufferDataReader } from "../../src/response_decoder"
+import { BufferDataReader, decodeFormatCode } from "../../src/response_decoder"
 import { getMaxSharedConnectionInstances, range } from "../../src/util"
 import {
   createClient,
@@ -385,6 +387,27 @@ describe("declare consumer", () => {
     })
   }).timeout(10000)
 
+  it("messageAnnotations with AMQP long encodings are read correctly", () => {
+    const key = "x-dotnet-pub-seq-no"
+    const smallLongAnnotations = Annotations.parse(
+      new BufferDataReader(Buffer.concat([encodeAmqpString(key), Buffer.from([FormatCode.SmallLong, 0x7f])])),
+      2
+    )
+
+    const longValue = Buffer.alloc(8)
+    longValue.writeBigInt64BE(128n)
+    const longAnnotations = Annotations.parse(
+      new BufferDataReader(Buffer.concat([encodeAmqpString(key), Buffer.from([FormatCode.Long]), longValue])),
+      2
+    )
+
+    expect(smallLongAnnotations).to.eql({ [key]: 127 })
+    expect(longAnnotations[key] as unknown).to.eql(128n)
+    expect(decodeFormatCode(new BufferDataReader(Buffer.from([0x7f])), FormatCode.SmallLong)).to.eql(
+      smallLongAnnotations[key]
+    )
+  }).timeout(10000)
+
   it("testing if messageHeader and amqpValue is decoded correctly using dataReader", async () => {
     const bufferedInput = readFileSync(path.join(...["test", "data", "header_amqpvalue_message"]))
     const dataReader = new BufferDataReader(bufferedInput)
@@ -559,4 +582,9 @@ function createMessageHeader(): MessageHeader {
     firstAcquirer: true,
     priority: 100,
   }
+}
+
+function encodeAmqpString(value: string) {
+  const data = Buffer.from(value)
+  return Buffer.concat([Buffer.from([FormatCode.Str8, data.length]), data])
 }


### PR DESCRIPTION
The `decodeFormatCode` function is missing support for the AMQP 1.0 `smalllong` (0x55) and `long` (0x81) type encodings, causing messages containing these types to throw `FormatCode Invalid type 85`.

This occurs in practice when consuming stream messages published by the .NET RabbitMQ client with publisher confirms enabled. The .NET client adds an `x-dotnet-pub-seq-no` header as a `long` value, which the broker encodes as `smalllong` (0x55) for values 0–127. The JS client then fails to parse the message annotations.

Per the [AMQP 1.0 specification](https://www.amqp.org/specification/1.0/amqp-org-download) (section 1.2.5, "List of encodings"), the `long` type has two valid encodings:
- `0x81` — fixed/8, 64-bit two's-complement integer in network byte order
- `0x55` (`smalllong`) — fixed/1, signed long value in the range -128 to 127 inclusive

This PR adds both to the `FormatCode` constants and `decodeFormatCode` switch.