### PR TITLE
Implement id recycling

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -57,6 +57,7 @@ import { coerce, lt } from "semver"
 import EventEmitter from "events"
 import { MetadataUpdateResponse } from "./responses/metadata_update_response"
 import { MetadataInfo } from "./responses/raw_response"
+import { IdAllocator } from "./id_allocator"
 import { StreamResponseError } from "./stream_response_error"
 
 /**
@@ -149,8 +150,8 @@ export class Connection {
   private filteringEnabled: boolean = false
   public userManuallyClose: boolean = false
   private setupCompleted: boolean = false
-  publisherId = 0
-  consumerId = 0
+  private consumersIdAllocator: IdAllocator = new IdAllocator()
+  private publishersIdAllocator: IdAllocator = new IdAllocator()
   private consumerListeners: ListenerEntry[] = []
   private publisherListeners: ListenerEntry[] = []
   private closeEventsEmitter = new EventEmitter()
@@ -703,15 +704,19 @@ export class Connection {
   }
 
   public getNextPublisherId() {
-    const publisherId = this.publisherId
-    this.publisherId++
-    return publisherId
+    return this.publishersIdAllocator.allocate()
+  }
+
+  public freePublisherId(id: number) {
+    this.publishersIdAllocator.free(id)
   }
 
   public getNextConsumerId() {
-    const consumerId = this.consumerId
-    this.consumerId++
-    return consumerId
+    return this.consumersIdAllocator.allocate()
+  }
+
+  public freeConsumerId(id: number) {
+    this.consumersIdAllocator.free(id)
   }
 }
 

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -162,11 +162,13 @@ export class StreamConsumer implements Consumer {
   async close(): Promise<void> {
     this.closed = true
     await this.pool.releaseConnection(this.connection, true)
+    this.connection.freeConsumerId(this.consumerId)
   }
 
   async automaticClose(): Promise<void> {
     this.closed = true
     await this.pool.releaseConnection(this.connection, false)
+    this.connection.freeConsumerId(this.consumerId)
   }
 
   public storeOffset(offsetValue?: bigint): Promise<void> {

--- a/src/id_allocator.ts
+++ b/src/id_allocator.ts
@@ -1,0 +1,21 @@
+export class IdAllocator {
+  private freeIds: number[]
+
+  constructor() {
+    this.freeIds = [...Array(256).keys()]
+  }
+
+  public allocate(): number {
+    const id = this.freeIds.shift()
+
+    if (id === undefined) {
+      throw new Error("No more ids available on this connection")
+    }
+
+    return id
+  }
+
+  public free(id: number) {
+    this.freeIds.push(id)
+  }
+}

--- a/src/publisher.ts
+++ b/src/publisher.ts
@@ -383,6 +383,7 @@ export class StreamPublisher implements Publisher {
     if (!this.closed) {
       await this.flush()
       await this.pool.releaseConnection(this.connection, true)
+      this.connection.freePublisherId(this.publisherId)
     }
     this._closed = true
   }
@@ -391,6 +392,7 @@ export class StreamPublisher implements Publisher {
     if (!this.closed) {
       await this.flush()
       await this.pool.releaseConnection(this.connection, false)
+      this.connection.freePublisherId(this.publisherId)
     }
     this._closed = true
   }

--- a/test/unit/id_allocator.test.ts
+++ b/test/unit/id_allocator.test.ts
@@ -1,0 +1,38 @@
+import { expect } from "chai"
+
+import { IdAllocator } from "../../src/id_allocator"
+
+describe("IdAllocator", () => {
+  it("allocates unique ids", () => {
+    const allocator = new IdAllocator()
+
+    const ids = Array.from({ length: 256 }, () => allocator.allocate())
+
+    expect(new Set(ids).size).to.equal(256)
+  })
+
+  it("throws when all ids are exhausted", () => {
+    const allocator = new IdAllocator()
+    for (let i = 0; i < 256; i++) allocator.allocate()
+
+    expect(() => allocator.allocate()).to.throw("No more ids available on this connection")
+  })
+
+  it("makes a freed id available again", () => {
+    const allocator = new IdAllocator()
+    const id = allocator.allocate()
+    allocator.free(id)
+
+    const ids = Array.from({ length: 256 }, () => allocator.allocate())
+    expect(ids).to.include(id)
+  })
+
+  it("reuses the freed id last (FIFO)", () => {
+    const allocator = new IdAllocator()
+    const id = allocator.allocate()
+    allocator.free(id)
+
+    const remaining = Array.from({ length: 256 }, () => allocator.allocate())
+    expect(remaining.at(-1)).to.equal(id)
+  })
+})


### PR DESCRIPTION
Introduce ID recycling for publishers and consumers on a per-connection basis. Replace monotonically-increasing `publisherId`/`consumerId` counters with an `IdAllocator` that reuses freed IDs, preventing errors when connections have many short-lived publish/consume sessions.

Closes #291 